### PR TITLE
Use datalog in MQTT packet topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Second thing is whenever the inverter receives a packet, it broadcasts the reply
 
 1 is actually any number from 1 to 179.
 
-These are unprocessed raw values, sent when the inverter tells us the contents of a register.  This is normally done in response to the inverter being asked for it (which you can do yourself with `lxp/cmd/read_hold/1`, see below).
+These are unprocessed raw values, sent when the inverter tells us the contents of a register.  This is normally done in response to the inverter being asked for it (which you can do yourself with `lxp/cmd/{datalog}/read_hold/1`, see below).
 
 In some cases, they require further processing to make much sense. For example, registers 2-6 contain the serial number, but it's returned as 5xu16 and needs separating into 10xu8 to match the result you'll see on the inverter's screen. Example 2; register 100 is the lead-acid discharge cut-out voltage, but is in 0.1V units, so divide by 10 to get Volts.
 
@@ -54,14 +54,14 @@ These are JSON hashes of transient data. There are 3 of them just because that's
 
 Not sure what determines the interval, and I'm pretty sure it used to be 2 minutes so this interval might be stored in a register somewhere?
 
-TODO: think you can request these to be sent immediately, once I make `lxp/cmd/read_inputs` work..
+TODO: think you can request these to be sent immediately, once I make `lxp/cmd/{datalog}/read_inputs` work..
 
 TODO: document the JSON hashes.
 
 
 ### Commands
 
-When you want lxp-bridge to do something, you send a message under `lxp/cmd/...`; responses to commands will be sent under `lxp/result/...` where ... is the same as the command you sent. So sending `lxp/cmd/set/ac_charge` will return a response under `lxp/result/ac_charge`. This will be `OK` or `FAIL` depending on the result.
+When you want lxp-bridge to do something, you send a message under `lxp/cmd/...`; responses to commands will be sent under `lxp/result/...` where ... is the same as the command you sent. So sending `lxp/cmd/{datalog}/set/ac_charge` will return a response under `lxp/result/{datalog}/ac_charge`. This will be `OK` or `FAIL` depending on the result.
 
 *boolean* values recognised as `true` in payloads are `1`, `t`, `true`, `on`, `y`, and `yes`. They're all equivalent. Anything else will be interpreted as `false`.
 
@@ -70,12 +70,12 @@ When you want lxp-bridge to do something, you send a message under `lxp/cmd/...`
 
 The following MQTT topics are recognised:
 
-#### topic = `lxp/cmd/set/ac_charge`, payload = boolean
+#### topic = `lxp/cmd/{datalog}/set/ac_charge`, payload = boolean
 
 Send a boolean to this to enable or disable immediate AC Charging.
 
 
-#### topic = `lxp/cmd/read/hold/1`, payload = empty
+#### topic = `lxp/cmd/{datalog}/read/hold/1`, payload = empty
 
 This is a pretty low-level command which you may not normally need.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ First thing to note is there are two types of registers in the inverter:
   * holdings - read/write, storing settings
   * inputs - read-only, storing transient power data, temperatures, counters etc
 
-### `lxp/hold/1`
+Second thing is whenever the inverter receives a packet, it broadcasts the reply out to *all* connected clients. So you may see unprompted messages for holding 12/13/14 for instance; this is LuxPower in China occasionally requesting the time from your inverter (presumably so they can correct it if needs be).
+
+
+### `lxp/{datalog}/hold/1`
 
 1 is actually any number from 1 to 179.
 
@@ -43,12 +46,11 @@ These are unprocessed raw values, sent when the inverter tells us the contents o
 
 In some cases, they require further processing to make much sense. For example, registers 2-6 contain the serial number, but it's returned as 5xu16 and needs separating into 10xu8 to match the result you'll see on the inverter's screen. Example 2; register 100 is the lead-acid discharge cut-out voltage, but is in 0.1V units, so divide by 10 to get Volts.
 
-
 You will see a whole bunch of these if you press "Read" under the Maintain tab in the LXP Web Monitor; this is the website reading all the values from your inverter so it can fill in the form with current values.
 
-### `lxp/inputs/1` (and 2, and 3)
+### `lxp/{datalog}/inputs/1` (and 2, and 3)
 
-These are JSON hashes of post-processed data. There are 3 of them just because that's how the inverter sends the data. They are sent at 3 minute intervals.
+These are JSON hashes of transient data. There are 3 of them just because that's how the inverter sends the data. They are sent at 5 minute intervals.
 
 Not sure what determines the interval, and I'm pretty sure it used to be 2 minutes so this interval might be stored in a register somewhere?
 
@@ -81,4 +83,6 @@ Publishing an empty message to this will read the value of register 1.
 
 The unprocessed reply will appear in `lxp/hold/1`. Depending on which register you're reading, this may need further post-processing to make sense.
 
+#### TODO: document the rest of them...
 
+there's more :)

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -139,11 +139,7 @@ impl Mqtt {
             topic: publish.topic,
             payload: String::from_utf8(publish.payload.to_vec())?,
         };
-
         debug!("RX: {:?}", message);
-
-        // ignore this message if it's not for this inverter
-
         self.to_coordinator.send(message)?;
 
         Ok(())

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -34,22 +34,22 @@ impl Message {
                 DeviceFunction::ReadHold => {
                     for (register, value) in t.pairs() {
                         r.push(Self {
-                            topic: format!("lxp/hold/{}", register),
+                            topic: format!("lxp/{}/hold/{}", t.datalog, register),
                             payload: serde_json::to_string(&value)?,
                         });
                     }
                 }
                 DeviceFunction::ReadInput => match t.register {
                     0 => r.push(Self {
-                        topic: String::from("lxp/inputs/1"),
+                        topic: format!("lxp/{}/inputs/1", t.datalog),
                         payload: serde_json::to_string(&t.read_input1()?)?,
                     }),
                     40 => r.push(Self {
-                        topic: String::from("lxp/inputs/2"),
+                        topic: format!("lxp/{}/inputs/2", t.datalog),
                         payload: serde_json::to_string(&t.read_input2()?)?,
                     }),
                     80 => r.push(Self {
-                        topic: String::from("lxp/inputs/3"),
+                        topic: format!("lxp/{}/inputs/3", t.datalog),
                         payload: serde_json::to_string(&t.read_input3()?)?,
                     }),
                     _ => {
@@ -62,7 +62,7 @@ impl Message {
             Packet::ReadParam(rp) => {
                 for (register, value) in rp.pairs() {
                     r.push(Self {
-                        topic: format!("lxp/param/{}", register),
+                        topic: format!("lxp/{}/param/{}", rp.datalog, register),
                         payload: serde_json::to_string(&value)?,
                     });
                 }


### PR DESCRIPTION
Closes #2

This changes the outgoing MQTT topics from `lxp/hold/1` to `lxp/$datalog/hold/1`. This lets people with multiple inverters distinguish which inverter is sending the messages.