### PR TITLE
[Test] Change time field to integer seconds (unix timestamp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.2.0
 
 * Add `lxp/cmd/{datalog}/read/inputs/{n}` functionality - read input registers on demand
+* Change `time` field of input packets from ISO8601 string to integer unix timestamp for better node-red compatibility
 
 
 # 0.1.0 - 24th June 2021

--- a/doc/inputs.md
+++ b/doc/inputs.md
@@ -113,8 +113,8 @@ Example structures are shown below with inline comments.
   "v_bus_1": 376.3,
   "v_bus_2": 304.1,
 
-  # UTC ISO8601 timestamp of when this data was received from the inverter
-  "time": "2021-06-22T07:05:08Z"
+  # unix timestamp of when this data was received from the inverter
+  "time": 1624793103
 }
 ```
 
@@ -162,8 +162,8 @@ Example structures are shown below with inline comments.
   # Number of seconds the inverter has been running; this does not reset on reboot
   "runtime": 38690201,
 
-  # UTC ISO8601 timestamp of when this data was received from the inverter
-  "time": "2021-06-22T06:55:09Z"
+  # unix timestamp of when this data was received from the inverter
+  "time": 1624793103
 }
 ```
 
@@ -205,7 +205,7 @@ Example structures are shown below with inline comments.
   # Ah capacity of the battery stack
   "bat_capacity": 0,
 
-  # UTC ISO8601 timestamp of when this data was received from the inverter
-  "time": "2021-06-22T06:59:10Z"
+  # unix timestamp of when this data was received from the inverter
+  "time": 1624793103
 }
 ```

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -96,7 +96,7 @@ pub struct ReadInput1 {
     pub v_bus_2: f64,
 
     #[nom(Parse = "utils::current_time")]
-    #[serde(skip)]
+    #[serde(serialize_with = "UnixTime::serialize")]
     pub time: UnixTime,
     #[nom(Ignore)]
     #[serde(skip)]
@@ -143,7 +143,7 @@ pub struct ReadInput2 {
     // bunch of auto_test stuff here I'm not doing yet
     //
     #[nom(Parse = "utils::current_time")]
-    #[serde(skip)]
+    #[serde(serialize_with = "UnixTime::serialize")]
     pub time: UnixTime,
     #[nom(Ignore)]
     #[serde(skip)]
@@ -182,7 +182,7 @@ pub struct ReadInput3 {
 
     // following are for influx capability only
     #[nom(Parse = "utils::current_time")]
-    #[serde(skip)]
+    #[serde(serialize_with = "UnixTime::serialize")]
     pub time: UnixTime,
     #[nom(Ignore)]
     #[serde(skip)]

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -96,7 +96,7 @@ pub struct ReadInput1 {
     pub v_bus_2: f64,
 
     #[nom(Parse = "utils::current_time")]
-    #[serde(serialize_with = "UnixTime::serialize")]
+    #[serde(skip)]
     pub time: UnixTime,
     #[nom(Ignore)]
     #[serde(skip)]
@@ -143,7 +143,7 @@ pub struct ReadInput2 {
     // bunch of auto_test stuff here I'm not doing yet
     //
     #[nom(Parse = "utils::current_time")]
-    #[serde(serialize_with = "UnixTime::serialize")]
+    #[serde(skip)]
     pub time: UnixTime,
     #[nom(Ignore)]
     #[serde(skip)]
@@ -182,7 +182,7 @@ pub struct ReadInput3 {
 
     // following are for influx capability only
     #[nom(Parse = "utils::current_time")]
-    #[serde(serialize_with = "UnixTime::serialize")]
+    #[serde(skip)]
     pub time: UnixTime,
     #[nom(Ignore)]
     #[serde(skip)]

--- a/src/unixtime.rs
+++ b/src/unixtime.rs
@@ -19,6 +19,9 @@ impl UnixTime {
     where
         S: Serializer,
     {
+        // previously used to send ISO8601 string. left for reference.
+        // serializer.serialize_str(&u.0.to_rfc3339_opts(chrono::SecondsFormat::Secs, true));
+
         serializer.serialize_i64(u.0.timestamp())
     }
 }

--- a/src/unixtime.rs
+++ b/src/unixtime.rs
@@ -19,13 +19,12 @@ impl UnixTime {
     where
         S: Serializer,
     {
-        let s = u.0.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
-        serializer.serialize_str(&s)
+        serializer.serialize_i64(u.0.timestamp())
     }
 }
 
 impl From<UnixTime> for influxdb::Timestamp {
     fn from(u: UnixTime) -> Self {
-        influxdb::Timestamp::Seconds(DateTime::timestamp(&u.0) as u128)
+        influxdb::Timestamp::Seconds(u.0.timestamp() as u128)
     }
 }


### PR DESCRIPTION
This should make node-red happier about parsing these input packets; don't think it liked the ISO8601 string format I was using previously, and this conveys exactly the same information anyway.