### PR TITLE
Publish hold message on receipt of WriteSingle packets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Fix "Channel closed" crash when MQTT is disabled (#31)
+* Fix: Send missing MQTT lxp/hold/XX message with new register value on receipt of a WriteSingle packet (#32)
 
 
 # 0.4.0 - 12th October 2021

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -393,7 +393,14 @@ impl Coordinator {
                         payload: serde_json::to_string(&r3)?,
                     }),
                 },
-                DeviceFunction::WriteSingle => {}
+                DeviceFunction::WriteSingle => {
+                    for (register, value) in t.pairs() {
+                        r.push(mqtt::Message {
+                            topic: format!("{}/hold/{}", t.datalog, register),
+                            payload: serde_json::to_string(&value)?,
+                        });
+                    }
+                }
                 DeviceFunction::WriteMulti => {}
             },
             Packet::ReadParam(rp) => {


### PR DESCRIPTION
The docs actually indicated this already happened, but it didn't.

So now, when you do:

```
mosquitto_pub -t lxp/cmd/all/set/hold/65 -m 100
```

Then the messages you see through MQTT are:

```
lxp/cmd/all/set/hold/65 100
lxp/BA12345678/hold/65 100
lxp/result/BA12345678/set/hold/65 OK
```

The first one is the command you sent, the second one is the new reply that was missing, the third was already present.

This new reply should be useful for updating home automation dashboards etc as it's the same message that gets published whenever that register changes.

WriteMulti should probably actually do this as well but I've not really tested that, so leaving it for now.