### PR TITLE
Merge "inputs" hashes when sending to InfluxDB and MQTT

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,4 +63,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/lxp-bridge
+          if-no-files-found: ignore
+          path: |
+            target/${{ matrix.target }}/release/lxp-bridge
+            target/${{ matrix.target }}/release/lxp-bridge.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Merge input data packets into one hash when publishing to MQTT and InfluxDB (#36)
+
+
 # 0.5.1 - 2nd November 2021
 
 * No functional changes; fix Windows build by bumping rumqttc crate to 0.10.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
 name = "async-channel"
@@ -68,9 +68,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cfg-if"
@@ -529,9 +529,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.106"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "linked-hash-map"
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "lxp-bridge"
-version = "0.5.1"
+version = "0.6.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -605,9 +605,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "minimal-lexical"
-version = "0.1.4"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c64630dcdd71f1a64c435f54885086a0de5d6a12d104d69b165fb7d5286d677"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -671,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.0.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffd9d26838a953b4af82cbeb9f1592c6798916983959be223a7124e992742c1"
+checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -1158,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
 dependencies = [
  "itoa",
  "ryu",
@@ -1318,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,7 +105,6 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "serde",
  "time",
  "winapi",
 ]
@@ -141,6 +152,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +189,12 @@ name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
@@ -465,46 +504,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "influxdb"
-version = "0.4.0"
-source = "git+https://github.com/celsworth/influxdb-rust#328c6206074ddd403dd900e71f3ca12501fc6b22"
-dependencies = [
- "chrono",
- "futures",
- "influxdb_derive",
- "lazy_static",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "influxdb_derive"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321345ebf687827f6254b36bb3077f00bdee36f609905d1e65d5905cc92156ab"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
+
+[[package]]
+name = "itertools"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -540,15 +552,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
-name = "lock_api"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,13 +572,14 @@ dependencies = [
  "enum_dispatch",
  "env_logger",
  "futures",
- "influxdb",
  "log",
  "net2",
  "nom",
  "nom-derive",
  "num_enum",
  "openssl",
+ "reqwest",
+ "rinfluxdb",
  "rumqttc",
  "serde",
  "serde_json",
@@ -812,31 +816,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,6 +965,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,6 +1012,23 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "rinfluxdb"
+version = "0.1.0"
+source = "git+https://gitlab.com/celsworth/rinfluxdb.git?branch=celsworth-master-patch-81884#f3f5b23ed6e2060de320a73ea984b7a0bae8ab70"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "csv",
+ "itertools",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1096,12 +1098,6 @@ dependencies = [
  "lazy_static",
  "winapi",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
@@ -1192,25 +1188,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
-
-[[package]]
-name = "smallvec"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "socket2"
@@ -1343,10 +1324,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "tokio-macros",
  "winapi",
 ]
@@ -1420,7 +1398,19 @@ checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1487,6 +1477,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lxp-bridge"
-version = "0.5.1"
+version = "0.6.0-dev"
 authors = ["Chris Elsworth <chris@cae.me.uk>"]
 edition = "2018"
 repository = "https://github.com/celsworth/lxp-bridge"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,7 @@ structopt = { version = "~0.3", default-features = false }
 chrono = "~0.4"
 enum_dispatch = "~0.3"
 async-trait = "~0.1"
-# git repo fork specified for tokio 1.0 compatibility
-influxdb = { version = "~0.4", features = ["derive"], git = "https://github.com/celsworth/influxdb-rust" }
+reqwest = "~0.11"
+rinfluxdb = { version = "~0.1", git = "https://gitlab.com/celsworth/rinfluxdb.git", branch = "celsworth-master-patch-81884" }
 
 openssl = { version = "~0.10", features = ["vendored"] }
-

--- a/README.md
+++ b/README.md
@@ -84,9 +84,13 @@ In some cases, they require further processing to make much sense. For example, 
 
 You will see a whole bunch of these if you press "Read" under the Maintain tab in the LXP Web Monitor; this is the website reading all the values from your inverter so it can fill in the form with current values.
 
-### `lxp/{datalog}/inputs/1` (and 2, and 3)
+### `lxp/{datalog}/inputs/all` (and 1, and 2, and 3)
 
-These are JSON hashes of transient data. There are 3 of them just because that's how the inverter sends the data. They are sent at 5 minute intervals. You can also read them on demand, see `lxp/cmd/{datalog}/read/inputs/1` below.
+These are hashes of transient data. The inverter sends these across 3 packets, which are directly mapped into JSON and published in `lxp/{datalog}/inputs/1`, `../2` and `../3`. From lxp-bridge v0.6.0, there is also an `../all` message which combines all three into a single hash of data.
+
+Eventually (not before lxp-bridge v1.0) the individual messages may be removed in favour of the new `all` message. Please prefer use of the `all` message in favour of the 1/2/3 messages in new projects.
+
+These are sent at 5 minute intervals. You can also read them on demand, see `lxp/cmd/{datalog}/read/inputs/1` below.
 
 Also see [inputs.md](doc/inputs.md) for details of the JSON data hashes.
 
@@ -117,7 +121,7 @@ The following MQTT topics are recognised:
 
 This prompts the inverter to immediately publish a set of input registers. These get published every few minutes anyway but with this you can read them on-demand.
 
-`1` can be 1 - 3.
+`1` can be 1 - 3. It is not yet possible to read all the registers at once, as seen in `lxp/{datalog}/inputs/all`.
 
 See [inputs.md](doc/inputs.md) for details of the JSON data hashes.
 

--- a/doc/inputs.md
+++ b/doc/inputs.md
@@ -2,12 +2,11 @@
 
 This document details the hash structure of "inputs" messages sent out by lxp-bridge. These correspond with transient read-only input registers on the inverter.
 
-Currently these are available over MQTT, at `lxp/{datalog}/inputs/{d}` where d is 1, 2, or 3.
+The inverter sends these across 3 packets, which are directly mapped into JSON and published in `lxp/{datalog}/inputs/1`, `../2` and `../3`. From lxp-bridge v0.6.0, there is also an `../all` message which combines all three into a single hash of data.
 
-They are also sent to InfluxDB, if enabled.
+Eventually (not before lxp-bridge v1.0) the individual messages may be removed in favour of the new `all` message. Please prefer use of the `all` message in favour of the 1/2/3 messages in new projects.
 
-Note that because the inverter sends the power data split across 3 packets, there will be 3 submissions to InfluxDB, each with slightly differing times (by about a second). This means all the data combined isn't an atomic snapshot of an instant in time, but in practise this shouldn't really matter.
-
+If InfluxDB is enabled, these values are sent as a single unified hash which matches the `all` MQTT message.
 
 Example structures are shown below with inline comments.
 

--- a/src/influx.rs
+++ b/src/influx.rs
@@ -1,19 +1,22 @@
 use crate::prelude::*;
 
-use influxdb::Client;
+use chrono::TimeZone;
+use rinfluxdb::line_protocol::{r#async::Client, LineBuilder};
 
 static INPUTS_MEASUREMENT: &str = "inputs";
 
+pub type ValueSender = broadcast::Sender<serde_json::Value>;
+
 pub struct Influx {
     config: Rc<Config>,
-    from_inverter: lxp::inverter::PacketChannelSender,
+    from_coordinator: ValueSender,
 }
 
 impl Influx {
-    pub fn new(config: Rc<Config>, from_inverter: lxp::inverter::PacketChannelSender) -> Self {
+    pub fn new(config: Rc<Config>, from_coordinator: ValueSender) -> Self {
         Self {
             config,
-            from_inverter,
+            from_coordinator,
         }
     }
 
@@ -27,45 +30,47 @@ impl Influx {
 
         info!("initializing influx at {}", config.url);
 
-        let mut client = Client::new(&config.url, &config.database);
+        let url = reqwest::Url::parse(&config.url)?;
+        let credentials = match (&config.username, &config.password) {
+            (Some(u), Some(p)) => Some((u, p)),
+            _ => None,
+        };
 
-        if let (Some(u), Some(p)) = (&config.username, &config.password) {
-            client = client.with_auth(u, p);
-        }
-
-        match client.ping().await {
-            Ok((b, v)) => {
-                info!("influx responding ok: build {}, version {}", b, v);
-            }
-            Err(e) => return Err(anyhow!("influx error: {}", e)),
-        }
+        let client = Client::new(url, credentials)?;
 
         futures::try_join!(self.sender(client))?;
 
         Ok(())
     }
 
-    async fn sender(&self, client: influxdb::Client) -> Result<()> {
-        use lxp::packet::{DeviceFunction, ReadInput};
-
-        let mut receiver = self.from_inverter.subscribe();
+    async fn sender(&self, client: rinfluxdb::line_protocol::r#async::Client) -> Result<()> {
+        let mut receiver = self.from_coordinator.subscribe();
 
         loop {
-            if let lxp::inverter::PacketChannelData::Packet(Packet::TranslatedData(td)) =
-                receiver.recv().await?
-            {
-                if td.device_function == DeviceFunction::ReadInput {
-                    let query = match td.read_input()? {
-                        ReadInput::ReadInput1(r1) => r1.into_query(INPUTS_MEASUREMENT),
-                        ReadInput::ReadInput2(r2) => r2.into_query(INPUTS_MEASUREMENT),
-                        ReadInput::ReadInput3(r3) => r3.into_query(INPUTS_MEASUREMENT),
-                    };
+            let mut line = LineBuilder::new(INPUTS_MEASUREMENT);
 
-                    while let Err(err) = client.query(&query).await {
-                        error!("push failed: {:?} - retrying in 10s", err);
-                        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-                    }
+            let data = receiver.recv().await?;
+
+            for (key, value) in data.as_object().unwrap() {
+                let key = key.to_string();
+
+                line = if key == "time" {
+                    line.set_timestamp(chrono::Utc.timestamp(value.as_i64().unwrap(), 0))
+                } else if key == "datalog" {
+                    line.insert_tag(key, value.as_str().unwrap())
+                } else if value.is_f64() {
+                    line.insert_field(key, value.as_f64().unwrap())
+                } else {
+                    // can't be anything other than int
+                    line.insert_field(key, value.as_u64().unwrap())
                 }
+            }
+
+            let lines = vec![line.build()];
+
+            while let Err(err) = client.send("lxp2", &lines).await {
+                error!("push failed: {:?} - retrying in 10s", err);
+                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
             }
         }
     }

--- a/src/influx.rs
+++ b/src/influx.rs
@@ -68,7 +68,7 @@ impl Influx {
 
             let lines = vec![line.build()];
 
-            while let Err(err) = client.send("lxp2", &lines).await {
+            while let Err(err) = client.send(&self.config.influx.database, &lines).await {
                 error!("push failed: {:?} - retrying in 10s", err);
                 tokio::time::sleep(std::time::Duration::from_secs(10)).await;
             }

--- a/src/lxp/inverter.rs
+++ b/src/lxp/inverter.rs
@@ -57,7 +57,7 @@ impl WaitForReply for PacketChannelReceiver {
 impl PacketChannelData {}
 
 // Serial {{{
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Serial([u8; 10]);
 
 impl Serial {

--- a/src/lxp/inverter.rs
+++ b/src/lxp/inverter.rs
@@ -3,6 +3,7 @@ use crate::prelude::*;
 use async_trait::async_trait;
 use bytes::BytesMut;
 use net2::TcpStreamExt; // for set_keepalive
+use serde::{Serialize, Serializer};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_util::codec::Decoder;
 
@@ -74,9 +75,12 @@ impl Serial {
     }
 }
 
-impl From<Serial> for influxdb::Type {
-    fn from(b: Serial) -> Self {
-        influxdb::Type::Text(b.to_string())
+impl Serialize for Serial {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
     }
 }
 

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -190,6 +190,26 @@ pub struct ReadInput3 {
     pub datalog: Serial, // serde skips this so its not in MQTT messages
 } // }}}
 
+#[derive(Debug, Serialize)]
+pub struct ReadInputs {
+    #[serde(flatten)]
+    pub read_input_1: Option<ReadInput1>,
+    #[serde(flatten)]
+    pub read_input_2: Option<ReadInput2>,
+    #[serde(flatten)]
+    pub read_input_3: Option<ReadInput3>,
+}
+
+impl ReadInputs {
+    pub fn default() -> Self {
+        Self {
+            read_input_1: None,
+            read_input_2: None,
+            read_input_3: None,
+        }
+    }
+}
+
 // {{{ TcpFunction
 #[derive(Clone, Copy, Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -12,7 +12,7 @@ pub enum ReadInput {
 }
 
 // {{{ ReadInput1
-#[derive(Debug, Serialize, Nom, InfluxDbWriteable)]
+#[derive(Debug, Serialize, Nom)]
 #[nom(LittleEndian)]
 pub struct ReadInput1 {
     pub status: u16,
@@ -96,16 +96,13 @@ pub struct ReadInput1 {
     pub v_bus_2: f64,
 
     #[nom(Parse = "utils::current_time")]
-    #[serde(serialize_with = "UnixTime::serialize")]
     pub time: UnixTime,
     #[nom(Ignore)]
-    #[serde(skip)]
-    #[influxdb(tag)]
-    pub datalog: Serial, // serde skips this so its not in MQTT messages
+    pub datalog: Serial,
 } // }}}
 
 // {{{ ReadInput2
-#[derive(Debug, Serialize, Nom, InfluxDbWriteable)]
+#[derive(Debug, Serialize, Nom)]
 #[nom(Debug, LittleEndian)]
 pub struct ReadInput2 {
     #[nom(Ignore)]
@@ -143,16 +140,13 @@ pub struct ReadInput2 {
     // bunch of auto_test stuff here I'm not doing yet
     //
     #[nom(Parse = "utils::current_time")]
-    #[serde(serialize_with = "UnixTime::serialize")]
     pub time: UnixTime,
     #[nom(Ignore)]
-    #[serde(skip)]
-    #[influxdb(tag)]
-    pub datalog: Serial, // serde skips this so its not in MQTT messages
+    pub datalog: Serial,
 } // }}}
 
 // {{{ ReadInput3
-#[derive(Debug, Serialize, Nom, InfluxDbWriteable)]
+#[derive(Debug, Serialize, Nom)]
 #[nom(LittleEndian)]
 pub struct ReadInput3 {
     #[nom(SkipBefore(2))] // bat_brand, bat_com_type
@@ -182,22 +176,19 @@ pub struct ReadInput3 {
 
     // following are for influx capability only
     #[nom(Parse = "utils::current_time")]
-    #[serde(serialize_with = "UnixTime::serialize")]
     pub time: UnixTime,
     #[nom(Ignore)]
-    #[serde(skip)]
-    #[influxdb(tag)]
-    pub datalog: Serial, // serde skips this so its not in MQTT messages
+    pub datalog: Serial,
 } // }}}
 
 #[derive(Debug, Serialize)]
 pub struct ReadInputs {
     #[serde(flatten)]
-    pub read_input_1: Option<ReadInput1>,
+    read_input_1: Option<ReadInput1>,
     #[serde(flatten)]
-    pub read_input_2: Option<ReadInput2>,
+    read_input_2: Option<ReadInput2>,
     #[serde(flatten)]
-    pub read_input_3: Option<ReadInput3>,
+    read_input_3: Option<ReadInput3>,
 }
 
 impl ReadInputs {
@@ -207,6 +198,17 @@ impl ReadInputs {
             read_input_2: None,
             read_input_3: None,
         }
+    }
+
+    pub fn set_read_input_1(&mut self, i: ReadInput1) {
+        self.read_input_1 = Some(i);
+    }
+    pub fn set_read_input_2(&mut self, i: ReadInput2) {
+        self.read_input_2 = Some(i);
+    }
+
+    pub fn set_read_input_3(&mut self, i: ReadInput3) {
+        self.read_input_3 = Some(i);
     }
 }
 

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -46,6 +46,15 @@ impl Message {
         Ok(r)
     }
 
+    pub fn for_inputs(inputs: &lxp::packet::ReadInputs) -> Vec<Message> {
+        let payload = serde_json::to_string(&inputs).unwrap();
+
+        vec![mqtt::Message {
+            topic: format!("{}/inputs/all", "foo".to_owned()),
+            payload,
+        }]
+    }
+
     pub fn for_input(td: lxp::packet::TranslatedData) -> Result<Vec<Message>> {
         use lxp::packet::ReadInput;
 

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -46,11 +46,14 @@ impl Message {
         Ok(r)
     }
 
-    pub fn for_inputs(inputs: &lxp::packet::ReadInputs) -> Vec<Message> {
+    pub fn for_inputs(
+        inputs: &lxp::packet::ReadInputs,
+        datalog: lxp::inverter::Serial,
+    ) -> Vec<Message> {
         let payload = serde_json::to_string(&inputs).unwrap();
 
         vec![mqtt::Message {
-            topic: format!("{}/inputs/all", "foo".to_owned()),
+            topic: format!("{}/inputs/all", datalog),
             payload,
         }]
     }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,8 +7,6 @@ pub use std::str::FromStr;
 pub use anyhow::{anyhow, bail, Error, Result};
 pub use log::{debug, error, info, trace, warn};
 
-pub use influxdb::InfluxDbWriteable;
-
 pub use tokio::sync::broadcast;
 
 pub use crate::{

--- a/src/unixtime.rs
+++ b/src/unixtime.rs
@@ -3,7 +3,7 @@
 // than good enough and should let Influx store it more efficiently.
 
 use chrono::{DateTime, Utc};
-use serde::Serializer;
+use serde::{Serialize, Serializer};
 
 #[derive(Debug)]
 pub struct UnixTime(DateTime<Utc>);
@@ -12,22 +12,15 @@ impl UnixTime {
     pub fn now() -> Self {
         Self(Utc::now())
     }
+}
 
-    // default chrono serialization uses RFC3339 with nanosecond precision..
-    // a bit overkill for our uses. clamp it to seconds.
-    pub fn serialize<S>(u: &UnixTime, serializer: S) -> Result<S::Ok, S::Error>
+// default chrono serialization uses RFC3339 with nanosecond precision..
+// a bit overkill for our uses. clamp it to seconds.
+impl Serialize for UnixTime {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        // previously used to send ISO8601 string. left for reference.
-        // serializer.serialize_str(&u.0.to_rfc3339_opts(chrono::SecondsFormat::Secs, true));
-
-        serializer.serialize_i64(u.0.timestamp())
-    }
-}
-
-impl From<UnixTime> for influxdb::Timestamp {
-    fn from(u: UnixTime) -> Self {
-        influxdb::Timestamp::Seconds(u.0.timestamp() as u128)
+        serializer.serialize_i64(self.0.timestamp())
     }
 }


### PR DESCRIPTION
This reworks the InfluxDB feeder by merging the 3 "inputs" packets into one. So previously you'd get 3 rows every 5 minutes in Influx, a second or two apart, meaning that charts weren't consistent and querying "last" values could get you nulls and so on, making maths harder than it needed to be. Now there's just one atomic set of data every 5 minutes. This completely replaces the old system.

Also, there's a new `lxp/{datalog}/inputs/all` MQTT message *in addition* to the previous `/1`, `/2`, and `/3` messages. The older ones are kept for compatibility purposes until at least lxp-bridge 1.0. But I'd recommend using the new unified message in new projects.

Closes #35