### PR TITLE
Rework workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,68 @@
+on:
+  pull_request:
+
+name: Build
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+
+    strategy:
+      matrix:
+        include:
+        - build: linux-x86_64
+          os: ubuntu-latest
+          toolchain: stable
+          target: x86_64-unknown-linux-gnu
+        - build: linux-aarch64
+          os: ubuntu-latest
+          toolchain: stable
+          target: aarch64-unknown-linux-gnu
+        - build: macos-x86_64
+          os: macos-11
+          toolchain: stable
+          target: x86_64-apple-darwin
+        - build: macos-aarch64
+          os: macos-11
+          toolchain: stable
+          target: aarch64-apple-darwin
+        - build: win-msvc
+          os: windows-2019
+          toolchain: stable
+          target: x86_64-pc-windows-msvc
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            /usr/share/rust~/.cargo/registry
+            /usr/share/rust~/.cargo/git
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          profile: minimal
+          override: true
+          target: ${{ matrix.target }}
+
+      - name: Build release binary
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --target ${{ matrix.target }}
+
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.target }}
+          path: .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,4 +63,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.target }}
-          path: target/
+          path: target/${{ matrix.target }}/release/lxp-bridge

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,4 +65,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.target }}
-          path: .
+          path: target/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,12 +39,10 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
-            /usr/share/rust~/.cargo/registry
-            /usr/share/rust~/.cargo/git
-            ~/.cargo/registry
-            ~/.cargo/git
+            /usr/share/rust~/.cargo
+            ~/.cargo
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: pull_request
 name: Lint
 jobs:
   lint:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,4 @@
 on:
-  push:
   release:
     types:
       - published

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,5 @@
 on:
+  push:
   release:
     types:
       - published
@@ -6,30 +7,6 @@ on:
 name: Release
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Login to DockerHub Registry
-        run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u celsworth --password-stdin
-
-      - name: Get the version
-        id: vars
-        run: echo ::set-output name=tag::$(echo ${GITHUB_REF:10})
-
-      - name: Build the tagged Docker image
-        run: docker build . --file Dockerfile --tag celsworth/lxp-bridge:${{steps.vars.outputs.tag}}
-
-      - name: Push the tagged Docker image
-        run: docker push celsworth/lxp-bridge:${{steps.vars.outputs.tag}}
-
-      - name: Tag the latest Docker image
-        run: docker tag celsworth/lxp-bridge:${{steps.vars.outputs.tag}} celsworth/lxp-bridge:latest
-
-      - name: Push the latest Docker image
-        run: docker push celsworth/lxp-bridge:latest
-
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
@@ -51,7 +28,7 @@ jobs:
           toolchain: stable
           target: aarch64-unknown-linux-musl
         - build: macos
-          os: macos-latest
+          os: macos-11
           toolchain: stable
           target: x86_64-apple-darwin
         - build: win-msvc
@@ -86,31 +63,3 @@ jobs:
           use-cross: true
           command: build
           args: --release --target ${{ matrix.target }}
-
-      - name: Set release version
-        shell: bash
-        run: |
-          echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-          echo "release version: $RELEASE_VERSION"
-
-      - name: Build archive
-        shell: bash
-        run: |
-          staging="lxp-bridge-${{ env.RELEASE_VERSION }}-${{ matrix.target }}"
-          mkdir -p "$staging"
-          cp "config.yaml.example" "$staging/"
-          if [ "${{ matrix.os }}" = "windows-2019" ]; then
-            cp "target/${{ matrix.target }}/release/lxp-bridge.exe" "$staging/"
-          else
-            cp "target/${{ matrix.target }}/release/lxp-bridge" "$staging/"
-            strip "$staging/lxp-bridge" || true
-          fi
-          7z a "$staging.zip" "$staging"
-          echo "ASSET=$staging.zip" >> $GITHUB_ENV
-
-      - name: Attach archive to release
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          hub release edit -m "" -a ${{ env.ASSET }} ${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,3 +66,5 @@ jobs:
 
       - name: Archive production artifacts
         uses: actions/upload-artifact@v2
+        with:
+          path: .

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,30 @@ on:
 name: Release
 
 jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Login to DockerHub Registry
+        run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u celsworth --password-stdin
+
+      - name: Get the version
+        id: vars
+        run: echo ::set-output name=tag::$(echo ${GITHUB_REF:10})
+
+      - name: Build the tagged Docker image
+        run: docker build . --file Dockerfile --tag celsworth/lxp-bridge:${{steps.vars.outputs.tag}}
+
+      - name: Push the tagged Docker image
+        run: docker push celsworth/lxp-bridge:${{steps.vars.outputs.tag}}
+
+      - name: Tag the latest Docker image
+        run: docker tag celsworth/lxp-bridge:${{steps.vars.outputs.tag}} celsworth/lxp-bridge:latest
+
+      - name: Push the latest Docker image
+        run: docker push celsworth/lxp-bridge:latest
+
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
@@ -64,7 +88,28 @@ jobs:
           command: build
           args: --release --target ${{ matrix.target }}
 
-      - name: Archive production artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          path: .
+      - name: Set release version
+        shell: bash
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          echo "release version: $RELEASE_VERSION"
+      - name: Build archive
+        shell: bash
+        run: |
+          staging="lxp-bridge-${{ env.RELEASE_VERSION }}-${{ matrix.target }}"
+          mkdir -p "$staging"
+          cp "config.yaml.example" "$staging/"
+          if [ "${{ matrix.os }}" = "windows-2019" ]; then
+            cp "target/${{ matrix.target }}/release/lxp-bridge.exe" "$staging/"
+          else
+            cp "target/${{ matrix.target }}/release/lxp-bridge" "$staging/"
+            strip "$staging/lxp-bridge" || true
+          fi
+          7z a "$staging.zip" "$staging"
+          echo "ASSET=$staging.zip" >> $GITHUB_ENV
+      - name: Attach archive to release
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          hub release edit -m "" -a ${{ env.ASSET }} ${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - build: linux
+        - build: linux-x86_64
           os: ubuntu-latest
           toolchain: stable
           target: x86_64-unknown-linux-musl
@@ -27,10 +27,14 @@ jobs:
           os: ubuntu-latest
           toolchain: stable
           target: aarch64-unknown-linux-musl
-        - build: macos
+        - build: macos-x86_64
           os: macos-11
           toolchain: stable
           target: x86_64-apple-darwin
+        - build: macos-aarch64
+          os: macos-11
+          toolchain: stable
+          target: aarch64-apple-darwin
         - build: win-msvc
           os: windows-2019
           toolchain: stable

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,12 +65,10 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
-            /usr/share/rust~/.cargo/registry
-            /usr/share/rust~/.cargo/git
-            ~/.cargo/registry
-            ~/.cargo/git
+            /usr/share/rust~/.cargo
+            ~/.cargo
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,15 +18,11 @@ jobs:
         - build: linux-x86_64
           os: ubuntu-latest
           toolchain: stable
-          target: x86_64-unknown-linux-musl
-        - build: linux-arm
-          os: ubuntu-latest
-          toolchain: stable
-          target: arm-unknown-linux-gnueabihf
+          target: x86_64-unknown-linux-gnu
         - build: linux-aarch64
           os: ubuntu-latest
           toolchain: stable
-          target: aarch64-unknown-linux-musl
+          target: aarch64-unknown-linux-gnu
         - build: macos-x86_64
           os: macos-11
           toolchain: stable
@@ -67,3 +63,6 @@ jobs:
           use-cross: true
           command: build
           args: --release --target ${{ matrix.target }}
+
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v2

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In future, it might possibly run a HTTP server with endpoints to fetch power dat
 
 ## Installation
 
-A range of binaries are provided on the Releases page, otherwise you can compile it yourself. It's written in Rust.
+A range of binaries are provided on the [Releases](https://github.com/celsworth/lxp-bridge/releases) page (if you're unsure which you need, start with `uname -m`), otherwise you can compile it yourself. It's written in Rust.
 
   1. [Install Rust](https://www.rust-lang.org/tools/install)
   1. `git clone https://github.com/celsworth/lxp-bridge.git`


### PR DESCRIPTION
* Add macOS M1 builds just because I can
* Use GNU for linux
* Remove ARM (ancient 32bit rubbish)
* Add a new Build flow that keeps artefacts for PR testing

https://doc.rust-lang.org/rustc/platform-support.html has a list of targets for future reference.

The macOS ones aren't that useful anyway because they cry about it being unsigned, but if you're persistent enough with the Security prefpane then they can be made to work.