### PR TITLE
Unvendor OpenSSL

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,12 @@ jobs:
             target
           key: ${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Install System Dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+            sudo apt-get update && apt-get install -y --no-install-recommends \
+            libssl-dev \
+
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,6 @@ jobs:
       - name: Build release binary
         uses: actions-rs/cargo@v1
         with:
-          use-cross: true
           command: build
           args: --release --target ${{ matrix.target }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
             sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-            libssl-dev \
+            pkg-config \
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,10 +16,6 @@ jobs:
           os: ubuntu-latest
           toolchain: stable
           target: x86_64-unknown-linux-gnu
-        - build: linux-aarch64
-          os: ubuntu-latest
-          toolchain: stable
-          target: aarch64-unknown-linux-gnu
         - build: macos-x86_64
           os: macos-11
           toolchain: stable
@@ -43,12 +39,6 @@ jobs:
             ~/.cargo
             target
           key: ${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Install System Dependencies
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-            sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-            pkg-config \
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Install System Dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |
-            sudo apt-get update && apt-get install -y --no-install-recommends \
+            sudo apt-get update && sudo apt-get install -y --no-install-recommends \
             libssl-dev \
 
       - name: Install Rust

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,10 +42,6 @@ jobs:
           os: ubuntu-latest
           toolchain: stable
           target: x86_64-unknown-linux-gnu
-        - build: linux-aarch64
-          os: ubuntu-latest
-          toolchain: stable
-          target: aarch64-unknown-linux-gnu
         - build: macos-x86_64
           os: macos-11
           toolchain: stable
@@ -81,7 +77,6 @@ jobs:
       - name: Build release binary
         uses: actions-rs/cargo@v1
         with:
-          use-cross: true
           command: build
           args: --release --target ${{ matrix.target }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,6 +470,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+dependencies = [
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "webpki",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,7 +592,6 @@ dependencies = [
  "nom",
  "nom-derive",
  "num_enum",
- "openssl-sys",
  "reqwest",
  "rinfluxdb",
  "rumqttc",
@@ -983,6 +997,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -992,15 +1007,18 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -1582,6 +1600,15 @@ checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
  "nom",
  "nom-derive",
  "num_enum",
- "openssl",
+ "openssl-sys",
  "reqwest",
  "rinfluxdb",
  "rumqttc",
@@ -793,15 +793,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
-name = "openssl-src"
-version = "300.0.2+3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a760a11390b1a5daf72074d4f6ff1a6e772534ae191f999f57e9ee8146d1fb"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,7 +801,6 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -1154,9 +1144,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
+checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,21 +470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
-dependencies = [
- "futures-util",
- "hyper",
- "log",
- "rustls",
- "tokio",
- "tokio-rustls",
- "webpki",
-]
-
-[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,7 +982,6 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1007,18 +991,15 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
  "winreg",
 ]
 
@@ -1600,15 +1581,6 @@ checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,4 @@ async-trait = "~0.1"
 reqwest = "~0.11"
 rinfluxdb = { version = "~0.1", git = "https://gitlab.com/celsworth/rinfluxdb.git", branch = "celsworth-master-patch-81884" }
 
-openssl = { version = "~0.10" }
+openssl-sys = { version = "~0.9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,5 @@ structopt = { version = "~0.3", default-features = false }
 chrono = "~0.4"
 enum_dispatch = "~0.3"
 async-trait = "~0.1"
-reqwest = { version = "~0.11", features = ["rustls-tls"] }
+reqwest = "~0.11"
 rinfluxdb = { version = "~0.1", git = "https://gitlab.com/celsworth/rinfluxdb.git", branch = "celsworth-master-patch-81884" }
-
-# openssl-sys = { version = "~0.9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,4 @@ async-trait = "~0.1"
 reqwest = "~0.11"
 rinfluxdb = { version = "~0.1", git = "https://gitlab.com/celsworth/rinfluxdb.git", branch = "celsworth-master-patch-81884" }
 
-openssl = { version = "~0.10", features = ["vendored"] }
+openssl = { version = "~0.10" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ structopt = { version = "~0.3", default-features = false }
 chrono = "~0.4"
 enum_dispatch = "~0.3"
 async-trait = "~0.1"
-reqwest = "~0.11"
+reqwest = { version = "~0.11", features = ["rustls-tls"] }
 rinfluxdb = { version = "~0.1", git = "https://gitlab.com/celsworth/rinfluxdb.git", branch = "celsworth-master-patch-81884" }
 
-openssl-sys = { version = "~0.9" }
+# openssl-sys = { version = "~0.9" }


### PR DESCRIPTION
Having OpenSSL statically built into the binary was never ideal - can be a security risk since OpenSSL doesn't get updated until lxp-bridge is updated.

The only casualty of this is not being able to build for aarch64 on Linux, which frankly I doubt anyone would ever use anyway.