### PR TITLE
Support arrays for configured databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.7.0
 
-* Add Postgres/MySQL/SQLite support (#44, #45)
+* Add Postgres/MySQL/SQLite support (#44, #45, #47)
 
 # 0.6.0 - 26th February 2022
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "der"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +732,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +881,7 @@ dependencies = [
  "rumqttc",
  "serde",
  "serde_json",
+ "serde_with",
  "serde_yaml",
  "sqlx",
  "structopt",
@@ -1581,6 +1623,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1e6ec4d8950e5b1e894eac0d360742f3b1407a6078a604a731c4b3f49cefbc"
+dependencies = [
+ "rustversion",
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1780,6 +1845,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ nom-derive = "~0.10"
 num_enum = "~0.5"
 rumqttc = "~0.10"
 serde = { version = "~1 ", features = ["derive"] }
+serde_with = "~1"
 serde_json = "~1"
 serde_yaml = "~0.8"
 tokio = { version = "~1", features = ["net"] }
@@ -28,5 +29,4 @@ enum_dispatch = "~0.3"
 async-trait = "~0.1"
 reqwest = "~0.11"
 rinfluxdb = { version = "~0.1", git = "https://gitlab.com/celsworth/rinfluxdb.git", rev = "f3f5b23e" }
-
 sqlx = { version = "~0.5", features = ["runtime-tokio-native-tls", "any", "postgres", "mysql", "sqlite", "chrono"] }

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -10,6 +10,12 @@ inverters:
   serial: 9999999999
   datalog: 3333333333
 
+databases:
+- enabled: false
+  url: postgres://lxp:lxp@localhost/lxp
+  # url: mysql://lxp:lxp@localhost/lxp
+  # url: sqlite://lxp.db
+
 mqtt:
   enabled: true
   host: localhost
@@ -27,9 +33,3 @@ influx:
   username:
   password:
   database: lxp
-
-database:
-  enabled: false
-  url: postgres://lxp:lxp@localhost/lxp
-  # url: mysql://lxp:lxp@localhost/lxp
-  # url: sqlite://lxp.db

--- a/doc/database.md
+++ b/doc/database.md
@@ -12,6 +12,8 @@ With the exception of SQLite which only needs a path to a file.
 
 A new row will be added to the `inputs` table every time the inverter broadcasts data.
 
+Note that the entry under `databases` is an array; you can configure multiple and lxp-bridge will store to each enabled one. Mixing and matching different database types is fine.
+
 ## Postgres
 
 Create a user and a database:
@@ -25,8 +27,8 @@ createdb -O lxpuser lxpdb
 config.yaml:
 
 ```yaml
-database:
-  enabled: true
+databases:
+- enabled: true
   url: postgres://lxpuser:lxppass@localhost/lxpdb
 ```
 
@@ -43,8 +45,8 @@ GRANT ALL PRIVILEGES ON lxpdb.* to lxpuser@localhost;
 config.yaml:
 
 ```yaml
-database:
-  enabled: true
+databases:
+- enabled: true
   url: mysql://lxpuser:lxppass@localhost/lxpdb
 ```
 
@@ -60,7 +62,7 @@ touch /some/path/to/lxp-database.db
 config.yaml:
 
 ```yaml
-database:
-  enabled: true
+databases:
+- enabled: true
   url: sqlite://some/path/to/lxp-database.db
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,13 +1,18 @@
 use crate::prelude::*;
 
 use serde::Deserialize;
+use serde_with::{serde_as, OneOrMany};
 
+#[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct Config {
     pub inverters: Vec<Inverter>,
+    //#[serde_as(deserialize_as = "OneOrMany<_>")]
     pub mqtt: Mqtt,
+    //#[serde_as(deserialize_as = "OneOrMany<_>")]
     pub influx: Influx,
-    pub database: Database,
+    #[serde(default = "Vec::new")]
+    pub databases: Vec<Database>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -31,7 +36,7 @@ where
     raw.parse().map_err(serde::de::Error::custom)
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct HomeAssistant {
     #[serde(default = "Config::default_mqtt_homeassistant_enabled")]
     pub enabled: bool,
@@ -40,7 +45,7 @@ pub struct HomeAssistant {
     pub prefix: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Mqtt {
     #[serde(default = "Config::default_mqtt_enabled")]
     pub enabled: bool,
@@ -58,7 +63,7 @@ pub struct Mqtt {
     pub homeassistant: HomeAssistant,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Influx {
     #[serde(default = "Config::default_influx_enabled")]
     pub enabled: bool,
@@ -70,7 +75,7 @@ pub struct Influx {
     pub database: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Database {
     #[serde(default = "Config::default_database_enabled")]
     pub enabled: bool,
@@ -141,6 +146,10 @@ impl Config {
     }
 
     fn default_database_enabled() -> bool {
-        false
+        true
+    }
+
+    pub fn enabled_databases(&self) -> impl Iterator<Item = &Database> {
+        self.databases.iter().filter(|database| database.enabled)
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
 use serde::Deserialize;
-use serde_with::{serde_as, OneOrMany};
+use serde_with::serde_as; //, OneOrMany;
 
 #[serde_as]
 #[derive(Debug, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,16 +45,12 @@ async fn app() -> Result<()> {
     info!("lxp-bridge {} starting", CARGO_PKG_VERSION);
 
     let config = Config::new(options.config_file)?;
+    println!("{:?}", config);
+    //return Ok(());
 
     let coordinator = Coordinator::new(config);
 
-    futures::try_join!(
-        coordinator.start(),
-        coordinator.inverter.start(),
-        coordinator.mqtt.start(),
-        coordinator.influx.start(),
-        coordinator.database.start()
-    )?;
+    futures::try_join!(coordinator.start())?;
 
     Ok(())
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -13,7 +13,8 @@ pub use crate::{
     command::Command,
     config::{self, Config},
     coordinator::Coordinator,
-    database, home_assistant, influx,
+    database::{self, Database},
+    home_assistant, influx,
     lxp::{
         self,
         inverter::{Inverter, Serial},


### PR DESCRIPTION
Improve the recent database support to be able to write to multiple configured databases.

This also fixes the databases key being missing entirely, and lays some groundwork for enhancing influx/mqtt to support multiple targets as well, just because I can and it would be consistent.