### PR TITLE
Set logging level in systemd service

### DIFF
--- a/systemd/lxp-bridge.service
+++ b/systemd/lxp-bridge.service
@@ -6,6 +6,7 @@ After=network-online.target
 User=root
 Restart=always
 RestartSec=5
+Environment="RUST_LOG=info"
 ExecStart=/usr/local/bin/lxp-bridge -c /etc/lxp-bridge/config.yaml
 
 [Install]


### PR DESCRIPTION
Setting the environment variable RUST_LOG to level 'info' prevents debug logging in syslog.