### PR TITLE
Consolidate channels setup

### DIFF
--- a/src/channels.rs
+++ b/src/channels.rs
@@ -1,0 +1,28 @@
+use crate::prelude::*;
+
+#[derive(Debug, Clone)]
+pub struct Channels {
+    pub from_inverter: broadcast::Sender<lxp::inverter::ChannelData>,
+    pub to_inverter: broadcast::Sender<lxp::inverter::ChannelData>,
+    pub from_mqtt: broadcast::Sender<mqtt::Message>,
+    pub to_mqtt: broadcast::Sender<mqtt::Message>,
+    pub to_influx: broadcast::Sender<influx::ChannelData>,
+    pub to_database: broadcast::Sender<database::ChannelData>,
+}
+
+impl Channels {
+    pub fn new() -> Self {
+        Self {
+            from_inverter: Self::channel(),
+            to_inverter: Self::channel(),
+            from_mqtt: Self::channel(),
+            to_mqtt: Self::channel(),
+            to_influx: Self::channel(),
+            to_database: Self::channel(),
+        }
+    }
+
+    fn channel<T: Clone>() -> broadcast::Sender<T> {
+        broadcast::channel(512).0 // we only need tx half
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod channels;
 pub mod command;
 pub mod config;
 pub mod coordinator;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,15 +1,18 @@
-pub use std::convert::TryFrom;
-pub use std::convert::TryInto;
-pub use std::io::Write;
-pub use std::rc::Rc;
-pub use std::str::FromStr;
+pub use std::{
+    convert::{TryFrom, TryInto},
+    io::Write,
+    rc::Rc,
+    str::FromStr,
+};
 
-pub use anyhow::{anyhow, bail, Error, Result};
-pub use log::{debug, error, info, trace, warn};
-
-pub use tokio::sync::broadcast;
+pub use {
+    anyhow::{anyhow, bail, Error, Result},
+    log::{debug, error, info, trace, warn},
+    tokio::sync::broadcast,
+};
 
 pub use crate::{
+    channels::Channels,
     command::Command,
     config::{self, Config},
     coordinator::{self, Coordinator},


### PR DESCRIPTION
Was starting to get a bit messy with all the channels. This abstracts that into a module so I can pass a single object, not lots of channels, around.

This will be marginally slower as the clones have more to do, but not enough to notice.