### PR TITLE
Add experimental Scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Allow enabling individual HomeAssistant discovery sensors (#56)
 * Support combined inputs data packet found in newer firmwares (#65)
 * Add WriteMulti packet support (#68)
+* Add scheduled tasks framework; first one is synchronize inverter clock (disabled by default) (#70)
 
 
 # 0.6.0 - 26th February 2022

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
+name = "cron-parser"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a5fad4b4a7de265e463214082759a751327fd8166ff21c7641e372155a9577"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +929,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc16",
+ "cron-parser",
  "enum_dispatch",
  "env_logger",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tokio = { version = "~1", features = ["net"] }
 tokio-util = { version = "~0.6", features = ["codec"] }
 structopt = { version = "~0.3", default-features = false }
 chrono = "~0.4"
+cron-parser = "~0.7"
 enum_dispatch = "~0.3"
 async-trait = "~0.1"
 reqwest = "~0.11"

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -34,3 +34,9 @@ influx:
   username:
   password:
   database: lxp
+
+scheduler:
+  enabled: false
+  timesync:
+    enabled: false
+    cron: "0 0 * * *"

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,11 +13,13 @@ pub struct Config {
     pub influx: Influx,
     #[serde(default = "Vec::new")]
     pub databases: Vec<Database>,
+
+    pub scheduler: Option<Scheduler>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Inverter {
-    #[serde(default = "Config::default_inverter_enabled")]
+    #[serde(default = "Config::default_enabled")]
     pub enabled: bool,
 
     pub host: String,
@@ -38,7 +40,7 @@ where
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct HomeAssistant {
-    #[serde(default = "Config::default_mqtt_homeassistant_enabled")]
+    #[serde(default = "Config::default_enabled")]
     pub enabled: bool,
 
     #[serde(default = "Config::default_mqtt_homeassistant_prefix")]
@@ -51,7 +53,7 @@ pub struct HomeAssistant {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Mqtt {
-    #[serde(default = "Config::default_mqtt_enabled")]
+    #[serde(default = "Config::default_enabled")]
     pub enabled: bool,
 
     pub host: String,
@@ -69,7 +71,7 @@ pub struct Mqtt {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Influx {
-    #[serde(default = "Config::default_influx_enabled")]
+    #[serde(default = "Config::default_enabled")]
     pub enabled: bool,
 
     pub url: String,
@@ -81,10 +83,26 @@ pub struct Influx {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Database {
-    #[serde(default = "Config::default_database_enabled")]
+    #[serde(default = "Config::default_enabled")]
     pub enabled: bool,
 
     pub url: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Scheduler {
+    #[serde(default = "Config::default_enabled")]
+    pub enabled: bool,
+
+    pub timesync: Crontab,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Crontab {
+    #[serde(default = "Config::default_enabled")]
+    pub enabled: bool,
+
+    pub cron: String,
 }
 
 impl Config {
@@ -116,13 +134,6 @@ impl Config {
         Ok(r)
     }
 
-    fn default_inverter_enabled() -> bool {
-        true
-    }
-
-    fn default_mqtt_enabled() -> bool {
-        true
-    }
     fn default_mqtt_port() -> u16 {
         1883
     }
@@ -132,15 +143,12 @@ impl Config {
 
     fn default_mqtt_homeassistant() -> HomeAssistant {
         HomeAssistant {
-            enabled: Self::default_mqtt_homeassistant_enabled(),
+            enabled: Self::default_enabled(),
             prefix: Self::default_mqtt_homeassistant_prefix(),
             sensors: Self::default_mqtt_homeassistant_sensors(),
         }
     }
 
-    fn default_mqtt_homeassistant_enabled() -> bool {
-        true
-    }
     fn default_mqtt_homeassistant_prefix() -> String {
         "homeassistant".to_string()
     }
@@ -149,11 +157,7 @@ impl Config {
         vec!["all".to_string()]
     }
 
-    fn default_influx_enabled() -> bool {
-        true
-    }
-
-    fn default_database_enabled() -> bool {
+    fn default_enabled() -> bool {
         true
     }
 

--- a/src/coordinator/commands/mod.rs
+++ b/src/coordinator/commands/mod.rs
@@ -1,1 +1,2 @@
 pub mod read_inputs;
+pub mod timesync;

--- a/src/coordinator/commands/timesync.rs
+++ b/src/coordinator/commands/timesync.rs
@@ -1,0 +1,93 @@
+use crate::prelude::*;
+
+use chrono::TimeZone;
+
+use lxp::{
+    inverter::WaitForReply,
+    packet::{DeviceFunction, TranslatedData},
+};
+
+pub struct TimeSync {
+    channels: Channels,
+    inverter: config::Inverter,
+}
+
+impl TimeSync {
+    pub fn new(channels: Channels, inverter: config::Inverter) -> Self {
+        Self { channels, inverter }
+    }
+
+    pub async fn run(&self) -> Result<()> {
+        let packet = Packet::TranslatedData(TranslatedData {
+            datalog: self.inverter.datalog,
+            device_function: DeviceFunction::ReadHold,
+            inverter: self.inverter.serial,
+            register: 12,
+            values: vec![3, 0],
+        });
+
+        let mut receiver = self.channels.from_inverter.subscribe();
+
+        self.channels
+            .to_inverter
+            .send(lxp::inverter::ChannelData::Packet(packet.clone()))?;
+
+        if let Packet::TranslatedData(td) = receiver.wait_for_reply(&packet).await? {
+            let year = td.values[0] as u32;
+            let month = td.values[1] as u32;
+            let day = td.values[2] as u32;
+            let hour = td.values[3] as u32;
+            let minute = td.values[4] as u32;
+            let second = td.values[5] as u32;
+
+            let dt = chrono::Local
+                .ymd(2000 + year as i32, month, day)
+                .and_hms(hour, minute, second);
+
+            let now = chrono::Local::now();
+
+            debug!(
+                "inverter {} time difference is {}",
+                self.inverter.datalog,
+                dt - now
+            );
+
+            let limit = chrono::Duration::seconds(10);
+
+            if dt - now > limit || now - dt > limit {
+                let packet = self.set_current_time_packet();
+                self.channels
+                    .to_inverter
+                    .send(lxp::inverter::ChannelData::Packet(packet.clone()))?;
+                if let Packet::TranslatedData(_) = receiver.wait_for_reply(&packet).await? {
+                    debug!("time set ok");
+                } else {
+                    warn!("time set didn't get confirmation reply!");
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn set_current_time_packet(&self) -> Packet {
+        use chrono::{Datelike, Timelike};
+
+        let now = chrono::Local::now();
+
+        Packet::TranslatedData(TranslatedData {
+            datalog: self.inverter.datalog,
+            device_function: DeviceFunction::WriteMulti,
+            inverter: self.inverter.serial,
+            register: 12,
+            values: vec![
+                (now.year() - 2000) as u8,
+                now.month() as u8,
+                now.day() as u8,
+                now.hour() as u8,
+                now.minute() as u8,
+                now.second() as u8,
+            ],
+        })
+    }
+}

--- a/src/coordinator/commands/timesync.rs
+++ b/src/coordinator/commands/timesync.rs
@@ -52,7 +52,7 @@ impl TimeSync {
                 dt - now
             );
 
-            let limit = chrono::Duration::seconds(10);
+            let limit = chrono::Duration::seconds(120);
 
             if dt - now > limit || now - dt > limit {
                 let packet = self.set_current_time_packet();

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -78,9 +78,18 @@ impl Coordinator {
             self.start_inverters(),
             self.mqtt_receiver(),
             self.start_databases(),
+            self.start_scheduler(),
             mqtt.start(),
             influx.start(),
         )?;
+
+        Ok(())
+    }
+
+    async fn start_scheduler(&self) -> Result<()> {
+        let scheduler = scheduler::Scheduler::new(Rc::clone(&self.config), self.channels.clone());
+
+        scheduler.start().await?;
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod lxp;
 pub mod mqtt;
 pub mod options;
 pub mod prelude;
+pub mod scheduler;
 pub mod unixtime;
 pub mod utils;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -25,6 +25,7 @@ pub use crate::{
     },
     mqtt,
     options::Options,
+    scheduler,
     unixtime::UnixTime,
     utils,
 };

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,0 +1,55 @@
+use crate::prelude::*;
+
+use cron_parser::parse;
+
+pub struct Scheduler {
+    config: Rc<Config>,
+    channels: Channels,
+}
+
+impl Scheduler {
+    pub fn new(config: Rc<Config>, channels: Channels) -> Self {
+        Self { config, channels }
+    }
+
+    pub async fn start(&self) -> Result<()> {
+        if let Some(config) = &self.config.scheduler {
+            if !config.enabled {
+                info!("scheduler disabled, skipping");
+                return Ok(());
+            }
+
+            info!("scheduler starting");
+
+            if config.timesync.enabled {
+                let timesync_config = &config.timesync;
+
+                while let Ok(next) = parse(&timesync_config.cron, &chrono::Local::now()) {
+                    let sleep = next - chrono::Local::now();
+                    info!("next timesync at {}, sleeping for {}", next, sleep);
+                    tokio::time::sleep(sleep.to_std()?).await;
+                    self.timesync().await?;
+                }
+            }
+
+            info!("scheduler exiting");
+        }
+
+        Ok(())
+    }
+
+    async fn timesync(&self) -> Result<()> {
+        info!("timesync starting");
+
+        let inverters = self.config.enabled_inverters().cloned();
+        for inverter in inverters {
+            coordinator::commands::timesync::TimeSync::new(self.channels.clone(), inverter)
+                .run()
+                .await?;
+        }
+
+        info!("timesync complete");
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This is a WIP way to run tasks on a schedule, set in configuration cron-style.

The first task is to check the inverter clock and correct it if necessary. Luxpower do this themselves already if the clock is more than a couple of minutes out, but since the goal of this project is to remove dependence on them, I figured it would be nice if we could do it ourselves.

This is disabled by default as there's no real need for it just yet.