### PR TITLE
Use zeroes as datalog/serial

### DIFF
--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -574,9 +574,9 @@ impl TcpFrameFactory {
         r[6] = 1; // unsure what this is, always seems to be 1
         r[7] = data.tcp_function() as u8;
 
-        r[8..18].copy_from_slice(&data.datalog().data());
+        //r[8..18].copy_from_slice(&data.datalog().data());
         // WIP - trying to work out how to learn the inverter sn
-        //r[8..18].copy_from_slice(&[0; 10]);
+        r[8..18].copy_from_slice(&[0; 10]);
 
         r[18..].copy_from_slice(&data_bytes);
 
@@ -817,9 +817,9 @@ impl PacketCommon for TranslatedData {
 
         // data[2] (address) is 0 when writing to inverter, 1 when reading from it
         data[3] = self.device_function as u8;
-        data[4..14].copy_from_slice(&self.inverter.data());
+        //data[4..14].copy_from_slice(&self.inverter.data());
         // WIP - trying to work out how to learn the datalog sn
-        //data[2..12].copy_from_slice(&[0xFF; 10]);
+        data[4..14].copy_from_slice(&[0x00; 10]);
         data[14..16].copy_from_slice(&self.register.to_le_bytes());
 
         if self.device_function == DeviceFunction::WriteMulti {


### PR DESCRIPTION
This may be the answer to #75.. maybe we don't even need the datalog/serial!?

Looking for feedback on this, if anyone tries it and it works please let me know. It works locally, but I'm convinced I tried this approach a few months back and didn't get any replies. Hmm..

Ignore failing CI, I just need to update tests.

* [ ] config still needs correct values or `wait_for_reply` times out and sends a FAIL message anyway even though it worked
* [ ] scheduler doesn't seem to get a reply even though sending exact same packet manually does..?

Had a report that it doesn't work at all on a newer firmware so it might be a no-go. Seems dodgy at best :(