### PR TITLE
Add some handling of incorrect serials in configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Support combined inputs data packet found in newer firmwares (#65)
 * Add internal WriteMulti packet support (not exposed to MQTT yet) (#68)
 * Add scheduled tasks framework; first one is synchronize inverter clock (disabled by default) (#70)
+* Log warning message when configured serial numbers don't match packets we receive from inverter (#78)
 
 
 # 0.6.0 - 26th February 2022

--- a/src/influx.rs
+++ b/src/influx.rs
@@ -48,7 +48,7 @@ impl Influx {
         Ok(())
     }
 
-    pub fn stop(&mut self) {
+    pub fn stop(&self) {
         let _ = self.channels.to_influx.send(ChannelData::Shutdown);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,13 +58,7 @@ async fn app() -> Result<()> {
     let inverters = config
         .enabled_inverters()
         .cloned()
-        .map(|inverter| {
-            Inverter::new(
-                inverter,
-                channels.to_inverter.clone(),
-                channels.from_inverter.clone(),
-            )
-        })
+        .map(|inverter| Inverter::new(inverter, channels.clone()))
         .collect();
 
     let databases = config

--- a/src/lxp/inverter.rs
+++ b/src/lxp/inverter.rs
@@ -290,7 +290,8 @@ impl Inverter {
                 "datalog serial mismatch found; packet={}, config={} - please check config!",
                 packet, b_datalog
             );
-            self.serials.borrow_mut().datalog = packet;
+            // uncomment this when I fix serials in outgoing packets?
+            //self.serials.borrow_mut().datalog = packet;
         }
     }
 
@@ -302,6 +303,7 @@ impl Inverter {
                 "inverter serial mismatch found; packet={}, config={} - please check config!",
                 packet, b_inverter
             );
+            // uncomment this when I fix serials in outgoing packets?
             self.serials.borrow_mut().inverter = packet;
         }
     }

--- a/src/lxp/inverter.rs
+++ b/src/lxp/inverter.rs
@@ -116,39 +116,52 @@ impl std::fmt::Debug for Serial {
     }
 } // }}}
 
+// these are kept separately because we learn what the correct ones are from the inverter
+struct Serials {
+    pub datalog: Serial,
+    pub inverter: Serial,
+}
+
 pub struct Inverter {
     config: config::Inverter,
-    from_coordinator: Sender,
-    to_coordinator: Sender,
+    channels: Channels,
+    serials: RefCell<Serials>,
 }
 
 impl Inverter {
-    pub fn new(config: config::Inverter, from_coordinator: Sender, to_coordinator: Sender) -> Self {
+    pub fn new(config: config::Inverter, channels: Channels) -> Self {
+        let serials = RefCell::new(Serials {
+            datalog: config.datalog,
+            inverter: config.serial,
+        });
+
         Self {
             config,
-            from_coordinator,
-            to_coordinator,
+            channels,
+            serials,
         }
     }
 
     pub async fn start(&self) -> Result<()> {
-        loop {
-            match self.connect().await {
-                Ok(_) => return Ok(()),
-                Err(e) => {
-                    error!("inverter {}: {}", self.config.datalog, e);
-                    info!("inverter {}: reconnecting in 5s", self.config.datalog);
-                    self.to_coordinator
-                        .send(ChannelData::Disconnect(self.config.datalog))?; // kill any waiting readers
-                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                }
-            }
+        while let Err(e) = self.connect().await {
+            error!("inverter {}: {}", self.config.datalog, e);
+            info!("inverter {}: reconnecting in 5s", self.config.datalog);
+            self.channels
+                .from_inverter
+                .send(ChannelData::Disconnect(self.config.datalog))?; // kill any waiting readers
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
         }
+
+        Ok(())
+    }
+
+    pub fn stop(&self) {
+        let _ = self.channels.to_inverter.send(ChannelData::Shutdown);
     }
 
     async fn connect(&self) -> Result<()> {
         use net2::TcpStreamExt; // for set_keepalive
-                                //
+
         info!(
             "connecting to inverter {} at {}:{}",
             &self.config.datalog, &self.config.host, self.config.port
@@ -186,14 +199,27 @@ impl Inverter {
                 while let Some(packet) = decoder.decode_eof(&mut buf)? {
                     // bytes received are logged in packet_decoder, no need here
                     //debug!("inverter {}: RX {:?}", self.config.datalog, packet);
-                    self.to_coordinator.send(ChannelData::Packet(packet))?;
+
+                    self.channels
+                        .from_inverter
+                        .send(ChannelData::Packet(packet))?;
                 }
                 break;
             }
 
             while let Some(packet) = decoder.decode(&mut buf)? {
-                debug!("inverter {}: RX {:?}", self.config.datalog, packet);
-                self.to_coordinator.send(ChannelData::Packet(packet))?;
+                // bytes received are logged in packet_decoder, no need here
+                //debug!("inverter {}: RX {:?}", self.config.datalog, packet);
+
+                self.channels
+                    .from_inverter
+                    .send(ChannelData::Packet(packet.clone()))?;
+
+                self.compare_datalog(packet.datalog()); // all packets have datalog serial
+                if let Packet::TranslatedData(td) = packet {
+                    // only TranslatedData has inverter serial
+                    self.compare_inverter(td.inverter);
+                };
             }
         }
 
@@ -202,18 +228,81 @@ impl Inverter {
 
     // coordinator -> inverter
     async fn sender(&self, mut socket: tokio::net::tcp::OwnedWriteHalf) -> Result<()> {
-        let mut receiver = self.from_coordinator.subscribe();
+        let mut receiver = self.channels.to_inverter.subscribe();
 
-        while let ChannelData::Packet(packet) = receiver.recv().await? {
-            if packet.datalog() == self.config.datalog {
-                //debug!("inverter {}: TX {:?}", self.config.datalog, packet);
-                let bytes = lxp::packet::TcpFrameFactory::build(&packet);
-                debug!("inverter {}: TX {:?}", self.config.datalog, bytes);
-                socket.write_all(&bytes).await?
+        use ChannelData::*;
+
+        loop {
+            match receiver.recv().await? {
+                Shutdown => break,
+                // this doesn't actually happen yet; Disconnect is never sent to this channel
+                Disconnect(_) => bail!("sender exiting due to ChannelData::Disconnect"),
+                Packet(packet) => {
+                    // this works, but needs more thought. because we only fix it here, immediately
+                    // before transmission, calls to wait_for_reply with the original serials will
+                    // never complete. ideally we need to pass the fixed packet back?
+                    //self.fix_outgoing_packet_serials(&mut packet);
+
+                    if packet.datalog() == self.serials.borrow().datalog {
+                        //debug!("inverter {}: TX {:?}", self.config.datalog, packet);
+                        let bytes = lxp::packet::TcpFrameFactory::build(&packet);
+                        debug!("inverter {}: TX {:?}", self.config.datalog, bytes);
+                        socket.write_all(&bytes).await?
+                    }
+                }
             }
         }
 
-        // this doesn't actually happen yet; Disconnect is never sent to this channel
-        Err(anyhow!("sender exiting due to ChannelData::Disconnect"))
+        info!("inverter {}: sender exiting", self.config.datalog);
+
+        Ok(())
+    }
+
+    /* TODO. need to solve wait_for_reply hanging when we fix the serials.. */
+    #[allow(dead_code)]
+    fn fix_outgoing_packet_serials(&self, packet: &mut Packet) {
+        let ob = self.serials.borrow();
+        if packet.datalog() != ob.datalog {
+            warn!(
+                "fixing datalog in outgoing packet from {} to {}",
+                packet.datalog(),
+                ob.datalog
+            );
+            packet.set_datalog(ob.datalog);
+        }
+
+        if let Some(inverter) = packet.inverter() {
+            if inverter != ob.inverter {
+                warn!(
+                    "fixing serial in outgoing packet from {} to {}",
+                    inverter, ob.inverter
+                );
+                packet.set_inverter(ob.inverter);
+            }
+        }
+    }
+
+    fn compare_datalog(&self, packet: Serial) {
+        let b_datalog = self.serials.borrow().datalog;
+
+        if packet != b_datalog {
+            warn!(
+                "datalog serial mismatch found; packet={}, config={} - please check config!",
+                packet, b_datalog
+            );
+            self.serials.borrow_mut().datalog = packet;
+        }
+    }
+
+    fn compare_inverter(&self, packet: Serial) {
+        let b_inverter = self.serials.borrow().inverter;
+
+        if packet != b_inverter {
+            warn!(
+                "inverter serial mismatch found; packet={}, config={} - please check config!",
+                packet, b_inverter
+            );
+            self.serials.borrow_mut().inverter = packet;
+        }
     }
 }

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -542,11 +542,12 @@ pub enum RegisterBit {
 #[enum_dispatch]
 pub trait PacketCommon {
     fn datalog(&self) -> Serial;
+    fn set_datalog(&mut self, datalog: Serial);
+    fn inverter(&self) -> Option<Serial>;
+    fn set_inverter(&mut self, serial: Serial);
     fn protocol(&self) -> u16;
     fn tcp_function(&self) -> TcpFunction;
-    fn bytes(&self) -> Vec<u8> {
-        Vec::new()
-    }
+    fn bytes(&self) -> Vec<u8>;
 
     fn register(&self) -> u16 {
         unimplemented!("register() not implemented");
@@ -634,9 +635,20 @@ impl PacketCommon for Heartbeat {
     fn datalog(&self) -> Serial {
         self.datalog
     }
+    fn set_datalog(&mut self, datalog: Serial) {
+        self.datalog = datalog;
+    }
+    fn inverter(&self) -> Option<Serial> {
+        None
+    }
+    fn set_inverter(&mut self, _datalog: Serial) {}
 
     fn tcp_function(&self) -> TcpFunction {
         TcpFunction::Heartbeat
+    }
+
+    fn bytes(&self) -> Vec<u8> {
+        Vec::new()
     }
 }
 
@@ -807,6 +819,16 @@ impl PacketCommon for TranslatedData {
     fn datalog(&self) -> Serial {
         self.datalog
     }
+    fn set_datalog(&mut self, datalog: Serial) {
+        self.datalog = datalog;
+    }
+
+    fn inverter(&self) -> Option<Serial> {
+        Some(self.inverter)
+    }
+    fn set_inverter(&mut self, serial: Serial) {
+        self.inverter = serial;
+    }
 
     fn tcp_function(&self) -> TcpFunction {
         TcpFunction::TranslatedData
@@ -929,6 +951,13 @@ impl PacketCommon for ReadParam {
     fn datalog(&self) -> Serial {
         self.datalog
     }
+    fn set_datalog(&mut self, datalog: Serial) {
+        self.datalog = datalog;
+    }
+    fn inverter(&self) -> Option<Serial> {
+        None
+    }
+    fn set_inverter(&mut self, _datalog: Serial) {}
 
     fn tcp_function(&self) -> TcpFunction {
         TcpFunction::ReadParam

--- a/tests/test_coordinator_commands_update_hold.rs
+++ b/tests/test_coordinator_commands_update_hold.rs
@@ -37,9 +37,11 @@ async fn happy_path() {
     };
 
     let tf = async {
+        let mut to_inverter = channels.to_inverter.subscribe();
+
         // wait for packet requesting current values
         assert_eq!(
-            unwrap_inverter_channeldata_packet(channels.to_inverter.subscribe().recv().await?),
+            unwrap_inverter_channeldata_packet(to_inverter.recv().await?),
             Packet::TranslatedData(lxp::packet::TranslatedData {
                 datalog: inverter.datalog,
                 device_function: lxp::packet::DeviceFunction::ReadHold,
@@ -63,7 +65,7 @@ async fn happy_path() {
 
         // wait for packet setting new value
         assert_eq!(
-            unwrap_inverter_channeldata_packet(channels.to_inverter.subscribe().recv().await?),
+            unwrap_inverter_channeldata_packet(to_inverter.recv().await?),
             Packet::TranslatedData(lxp::packet::TranslatedData {
                 datalog: inverter.datalog,
                 device_function: lxp::packet::DeviceFunction::WriteSingle,
@@ -116,7 +118,7 @@ async fn no_reply() {
             result.unwrap_err().to_string(),
             "wait_for_reply TranslatedData(TranslatedData { datalog: 2222222222, device_function: ReadHold, inverter: 5555555555, register: 21, values: [1, 0] }) - timeout"
         );
-        Ok(())
+        Ok::<(), anyhow::Error>(())
     };
 
     let tf = async {

--- a/tests/test_inverter.rs
+++ b/tests/test_inverter.rs
@@ -1,0 +1,92 @@
+mod common;
+use common::*;
+
+#[allow(dead_code)]
+//#[tokio::test]
+async fn serials_fixed_in_outgoing_packets() {
+    // in this test, we configure an inverter with serials of 0000000000, but make the fake
+    // inverter talk to us using a serial of XXXXXXXXXX. We expect the final packet to be
+    // sent to the inverter using the corrected serials.
+
+    common_setup();
+
+    let config = config::Inverter {
+        enabled: true,
+        host: "localhost".to_owned(),
+        port: 1235,
+        datalog: Serial::from_str("0000000000").unwrap(),
+        serial: Serial::from_str("0000000000").unwrap(),
+    };
+    let channels = Channels::new();
+    let inverter = lxp::inverter::Inverter::new(config, channels.clone());
+
+    let mut from_inverter = channels.from_inverter.subscribe();
+
+    let tf = async {
+        // pretend to be an inverter
+        let listener = tokio::net::TcpListener::bind("localhost:1235")
+            .await
+            .unwrap();
+
+        let (socket, _) = listener.accept().await?;
+
+        // send a packet from inverter with the correct serials
+        socket.writable().await?;
+        socket
+            .try_write(&[
+                161, 26, 2, 0, 111, 0, 1, 194, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 97, 0, 1, 4,
+                88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 0, 0, 80, 16, 0, 0, 0, 0, 0, 0, 0, 233, 1,
+                44, 0, 0, 47, 0, 0, 0, 0, 0, 0, 0, 0, 89, 9, 124, 9, 0, 16, 0, 0, 134, 19, 105, 8,
+                0, 0, 124, 3, 232, 3, 124, 9, 0, 10, 80, 112, 134, 19, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 75, 0, 3, 0, 3, 0, 95, 0, 0, 0, 1, 0, 26, 0, 98, 14, 33, 11, 151,
+                62,
+            ])
+            .unwrap();
+
+        assert_eq!(
+            unwrap_inverter_channeldata_packet(from_inverter.recv().await.unwrap()),
+            Packet::TranslatedData(lxp::packet::TranslatedData {
+                datalog: Serial::from_str("XXXXXXXXXX").unwrap(),
+                device_function: lxp::packet::DeviceFunction::ReadInput,
+                inverter: Serial::from_str("XXXXXXXXXX").unwrap(),
+                register: 0,
+                values: vec![
+                    16, 0, 0, 0, 0, 0, 0, 0, 233, 1, 44, 0, 0, 47, 0, 0, 0, 0, 0, 0, 0, 0, 89, 9,
+                    124, 9, 0, 16, 0, 0, 134, 19, 105, 8, 0, 0, 124, 3, 232, 3, 124, 9, 0, 10, 80,
+                    112, 134, 19, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 75, 0, 3, 0, 3, 0, 95,
+                    0, 0, 0, 1, 0, 26, 0, 98, 14, 33, 11,
+                ]
+            })
+        );
+
+        let packet = Packet::TranslatedData(lxp::packet::TranslatedData {
+            datalog: Serial::from_str("0000000000").unwrap(),
+            device_function: lxp::packet::DeviceFunction::ReadInput,
+            inverter: Serial::from_str("0000000000").unwrap(),
+            register: 12,
+            values: vec![1, 0],
+        });
+        channels
+            .to_inverter
+            .send(lxp::inverter::ChannelData::Packet(packet))
+            .unwrap();
+
+        // wait for inverter to receive the ReadHold and verify the serials have been replaced
+        socket.readable().await?;
+        let mut buf = [0; 38];
+        assert_eq!(38, socket.try_read(&mut buf).unwrap());
+        assert_eq!(
+            buf.to_vec(),
+            &[
+                161, 26, 1, 0, 32, 0, 1, 194, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 18, 0, 0, 4,
+                88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 12, 0, 1, 0, 220, 47
+            ]
+        );
+
+        inverter.stop();
+
+        Ok::<(), anyhow::Error>(())
+    };
+
+    futures::try_join!(tf, inverter.start()).unwrap();
+}


### PR DESCRIPTION
Part of #75 

This is a first step, and will log warnings when we get a packet from the inverter that doesn't match the configuration datalog/serials. This should serve at least as a hint that the configuration is wrong.

There's more to do here, I've started a system to actually auto-correct it, but it needs more thought as `wait_for_reply` hangs and times out because its expecting a reply with the wrong serial numbers. Not really thought about how to fix this yet.