### PR TITLE
Ignore unhandled ReadInputs combinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.8.0 - Unreleased
 
 * Publish MQTT discovery packets with Retain bit set (#86)
+* Be more tolerant of unknown ReadInputs registers (#89)
 
 
 # 0.7.0 - 26th June 2022

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -682,10 +682,11 @@ impl TranslatedData {
         // note len() is of Vec<u8>, so not register count
         match (self.register, self.values.len()) {
             (0, 254) => Ok(ReadInput::ReadInputAll(Box::new(self.read_input_all()?))),
+            // (127, 254) has been seen but containing all zeroes, not sure what they are
             (0, 80) => Ok(ReadInput::ReadInput1(self.read_input1()?)),
             (40, 80) => Ok(ReadInput::ReadInput2(self.read_input2()?)),
             (80, 80) => Ok(ReadInput::ReadInput3(self.read_input3()?)),
-            (r1, r2) => Err(anyhow!("unhandled ReadInput register={} len={}", r1, r2)),
+            (r1, r2) => bail!("unhandled ReadInput register={} len={}", r1, r2),
         }
     }
 

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -61,23 +61,26 @@ impl Message {
 
         let mut r = Vec::new();
 
-        match td.read_input()? {
-            ReadInput::ReadInputAll(r_all) => r.push(mqtt::Message {
+        match td.read_input() {
+            Ok(ReadInput::ReadInputAll(r_all)) => r.push(mqtt::Message {
                 topic: format!("{}/inputs/all", td.datalog),
                 payload: serde_json::to_string(&r_all)?,
             }),
-            ReadInput::ReadInput1(r1) => r.push(mqtt::Message {
+            Ok(ReadInput::ReadInput1(r1)) => r.push(mqtt::Message {
                 topic: format!("{}/inputs/1", td.datalog),
                 payload: serde_json::to_string(&r1)?,
             }),
-            ReadInput::ReadInput2(r2) => r.push(mqtt::Message {
+            Ok(ReadInput::ReadInput2(r2)) => r.push(mqtt::Message {
                 topic: format!("{}/inputs/2", td.datalog),
                 payload: serde_json::to_string(&r2)?,
             }),
-            ReadInput::ReadInput3(r3) => r.push(mqtt::Message {
+            Ok(ReadInput::ReadInput3(r3)) => r.push(mqtt::Message {
                 topic: format!("{}/inputs/3", td.datalog),
                 payload: serde_json::to_string(&r3)?,
             }),
+            Err(x) => {
+                warn!("ignoring {:?}", x);
+            }
         }
 
         Ok(r)

--- a/tests/test_mqtt_message.rs
+++ b/tests/test_mqtt_message.rs
@@ -44,6 +44,7 @@ async fn for_hold_single() {
         }]
     );
 }
+
 #[tokio::test]
 async fn for_hold_multi() {
     common_setup();
@@ -75,4 +76,44 @@ async fn for_hold_multi() {
             },
         ]
     );
+}
+
+#[tokio::test]
+async fn for_input() {
+    common_setup();
+
+    let inverter = Factory::inverter();
+
+    let packet = lxp::packet::TranslatedData {
+        datalog: inverter.datalog,
+        device_function: lxp::packet::DeviceFunction::ReadInput,
+        inverter: inverter.serial,
+        register: 0,
+        values: [0; 80].to_vec(),
+    };
+
+    assert_eq!(
+        mqtt::Message::for_input(packet).unwrap(),
+        vec![mqtt::Message {
+            topic: "2222222222/inputs/1".to_owned(),
+            payload: "{\"status\":0,\"v_pv\":0.0,\"v_pv_1\":0.0,\"v_pv_2\":0.0,\"v_pv_3\":0.0,\"v_bat\":0.0,\"soc\":0,\"soh\":0,\"p_pv\":0,\"p_pv_1\":0,\"p_pv_2\":0,\"p_pv_3\":0,\"p_charge\":0,\"p_discharge\":0,\"v_ac_r\":0.0,\"v_ac_s\":0.0,\"v_ac_t\":0.0,\"f_ac\":0.0,\"p_inv\":0,\"p_rec\":0,\"pf\":0.0,\"v_eps_r\":0.0,\"v_eps_s\":0.0,\"v_eps_t\":0.0,\"f_eps\":0.0,\"p_to_grid\":0,\"p_to_user\":0,\"e_pv_day\":0.0,\"e_pv_day_1\":0.0,\"e_pv_day_2\":0.0,\"e_pv_day_3\":0.0,\"e_inv_day\":0.0,\"e_rec_day\":0.0,\"e_chg_day\":0.0,\"e_dischg_day\":0.0,\"e_eps_day\":0.0,\"e_to_grid_day\":0.0,\"e_to_user_day\":0.0,\"v_bus_1\":0.0,\"v_bus_2\":0.0,\"time\":1646370367,\"datalog\":\"2222222222\"}".to_owned()
+        }]
+    );
+}
+
+#[tokio::test]
+async fn for_input_ignore_127_254() {
+    common_setup();
+
+    let inverter = Factory::inverter();
+
+    let packet = lxp::packet::TranslatedData {
+        datalog: inverter.datalog,
+        device_function: lxp::packet::DeviceFunction::ReadInput,
+        inverter: inverter.serial,
+        register: 127,
+        values: [0; 254].to_vec(),
+    };
+
+    assert_eq!(mqtt::Message::for_input(packet).unwrap(), vec![]);
 }


### PR DESCRIPTION
We've been getting a few bug reports about this, because lxp-bridge is a bit too paranoid about receiving packets with unhandled values and disconnects/exits.

In summary, the inverter sends data at regular intervals about power flows etc, which are called ReadInputs packets (they're reading input registers). When I first started this project, my inverter sent me 3 sets of packets, which had registers 0-39, 40-79, and 80-119.
Newer inverters appear to send more/different packets; so far we've had 0-127 reported, and more recently 127-254. 0-127 are easy to deal with as they're simply a merging of the 3 previous known packets; but 127-254 are thus far unknown. More investigation can be done into these in due course, but for now this change will stop lxp-bridge bailing out and will now ignore them and log a WARN message instead.

I have been sent a debug packet with the 127-254 values but they're all zeroes so perhaps they're just not used yet anyway.

Fixes #88 (for now).