### PR TITLE
Ignore WriteParam packets, don't disconnect/exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 * Publish MQTT discovery packets with Retain bit set (#86)
 * Be more tolerant of unknown ReadInputs registers (#89)
-* Add a bit more logging around unhandled tcp_function packets (#90)
 * Add missing p_eps and s_eps fields to ReadInput1 (#91)
+* Ignore unhandled WriteParam (tcp_function=196) packets (#92)
 
 
 # 0.7.0 - 26th June 2022

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -5,7 +5,7 @@ pub mod commands;
 use lxp::inverter::WaitForReply;
 use lxp::packet::{DeviceFunction, ReadParam, TcpFunction};
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 pub enum ChannelData {
     Shutdown,
 }
@@ -367,6 +367,7 @@ impl Coordinator {
                 DeviceFunction::WriteMulti => Ok(Vec::new()), // TODO, for_hold might just work
             },
             Packet::ReadParam(rp) => mqtt::Message::for_param(rp),
+            Packet::WriteParam(_) => Ok(Vec::new()), // ignoring for now
         }
     }
 }

--- a/src/influx.rs
+++ b/src/influx.rs
@@ -5,7 +5,7 @@ use rinfluxdb::line_protocol::{r#async::Client, LineBuilder};
 
 static INPUTS_MEASUREMENT: &str = "inputs";
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub enum ChannelData {
     InputData(serde_json::Value),
     Shutdown,

--- a/src/lxp/inverter.rs
+++ b/src/lxp/inverter.rs
@@ -6,7 +6,7 @@ use {
     tokio::io::{AsyncReadExt, AsyncWriteExt},
 };
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 pub enum ChannelData {
     Disconnect(Serial), // strictly speaking, only ever goes inverter->coordinator, but eh.
     Packet(Packet),     // this one goes both ways through the channel.

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -1034,7 +1034,7 @@ impl WriteParam {
 
         if values.len() != value_len {
             bail!(
-                "ReadParam::decode mismatch: values.len()={}, value_length_byte={}",
+                "WriteParam::decode mismatch: values.len()={}, value_length_byte={}",
                 values.len(),
                 value_len
             );
@@ -1047,8 +1047,8 @@ impl WriteParam {
         })
     }
 
-    fn has_value_length_bytes(protocol: u16) -> bool {
-        protocol == 2
+    fn has_value_length_bytes(_protocol: u16) -> bool {
+        false
     }
 }
 

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -973,11 +973,7 @@ impl PacketCommon for ReadParam {
     }
 
     fn bytes(&self) -> Vec<u8> {
-        let mut r = vec![0; 2];
-
-        r[0..2].copy_from_slice(&self.register.to_le_bytes());
-
-        r
+        vec![self.register() as u8, 0]
     }
 
     fn register(&self) -> u16 {
@@ -1073,9 +1069,10 @@ impl PacketCommon for WriteParam {
     }
 
     fn bytes(&self) -> Vec<u8> {
-        let mut r = vec![0; 2];
+        let mut r = vec![0; 3];
 
-        r[0..2].copy_from_slice(&self.register.to_le_bytes());
+        r[0] = self.register() as u8;
+        r[1..3].copy_from_slice(&self.value().to_le_bytes());
 
         r
     }

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -1069,12 +1069,20 @@ impl PacketCommon for WriteParam {
     }
 
     fn bytes(&self) -> Vec<u8> {
-        let mut r = vec![0; 3];
+        let mut data = vec![0; 2];
 
-        r[0] = self.register() as u8;
-        r[1..3].copy_from_slice(&self.value().to_le_bytes());
+        data[0..2].copy_from_slice(&self.register.to_le_bytes());
 
-        r
+        let len = self.values.len() as u16;
+        data.extend_from_slice(&len.to_le_bytes());
+
+        let mut m = Vec::new();
+        for i in &self.values {
+            m.extend_from_slice(&i.to_le_bytes());
+        }
+        data.append(&mut m);
+
+        data
     }
 
     fn register(&self) -> u16 {

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -1012,7 +1012,7 @@ impl WriteParam {
 
     fn decode(input: &[u8]) -> Result<Self> {
         let len = input.len();
-        if len < 24 {
+        if len < 21 {
             bail!("packet too short");
         }
 
@@ -1020,10 +1020,10 @@ impl WriteParam {
         let datalog = Serial::new(&input[8..18])?;
 
         let data = &input[18..];
-        let register = Utils::u16ify(data, 0);
+        let register = u16::from(data[0]);
 
         let mut value_len = 2;
-        let mut value_offset = 2;
+        let mut value_offset = 1;
 
         if Self::has_value_length_bytes(protocol) {
             value_len = Utils::u16ify(data, value_offset) as usize;

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 use rumqttc::{AsyncClient, Event, EventLoop, Incoming, MqttOptions, Publish, QoS};
 
 // Message {{{
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 pub struct Message {
     pub topic: String,
     pub payload: String,
@@ -160,7 +160,7 @@ impl Message {
     }
 } // }}}
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 pub enum ChannelData {
     Message(Message),
     Shutdown,

--- a/src/unixtime.rs
+++ b/src/unixtime.rs
@@ -6,7 +6,7 @@ use crate::utils::Utils;
 
 use serde::{Serialize, Serializer};
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct UnixTime(pub chrono::DateTime<chrono::Utc>);
 
 impl UnixTime {

--- a/tests/test_packet_tcp_frames.rs
+++ b/tests/test_packet_tcp_frames.rs
@@ -223,6 +223,21 @@ fn parse_write_multi_reply() {
 }
 
 #[test]
+fn build_write_param() {
+    // this isn't hooked up yet anyway, no way to make a WriteParam packet from MQTT
+    let packet = Packet::WriteParam(lxp::packet::WriteParam {
+        datalog: datalog(),
+        register: 7,
+        values: vec![0, 3],
+    });
+
+    assert_eq!(
+        lxp::packet::TcpFrameFactory::build(&packet),
+        vec![161, 26, 2, 0, 15, 0, 1, 196, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 7, 0, 3,]
+    );
+}
+
+#[test]
 fn parse_write_param_reply() {
     let input = [
         161, 26, 2, 0, 15, 0, 1, 196, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 7, 0, 3,

--- a/tests/test_packet_tcp_frames.rs
+++ b/tests/test_packet_tcp_frames.rs
@@ -221,3 +221,19 @@ fn parse_write_multi_reply() {
         })
     );
 }
+
+#[test]
+fn parse_write_param_reply() {
+    let input = [
+        161, 26, 2, 0, 15, 0, 1, 196, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 7, 0, 3,
+    ];
+
+    assert_eq!(
+        lxp::packet::Parser::parse(&input).unwrap(),
+        Packet::WriteParam(lxp::packet::WriteParam {
+            datalog: datalog(),
+            register: 7,
+            values: vec![0, 3]
+        })
+    );
+}

--- a/tests/test_packet_tcp_frames.rs
+++ b/tests/test_packet_tcp_frames.rs
@@ -223,8 +223,39 @@ fn parse_write_multi_reply() {
 }
 
 #[test]
+fn build_read_param() {
+    let packet = Packet::ReadParam(lxp::packet::ReadParam {
+        datalog: datalog(),
+        register: 7,
+        values: vec![0, 0], // not used?
+    });
+
+    assert_eq!(
+        lxp::packet::TcpFrameFactory::build(&packet),
+        vec![161, 26, 2, 0, 14, 0, 1, 195, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 7, 0]
+    );
+}
+
+#[test]
+fn parse_read_param_reply() {
+    let input = [
+        161, 26, 2, 0, 18, 0, 1, 195, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 0, 0, 2, 0, 44, 1,
+    ];
+
+    assert_eq!(
+        lxp::packet::Parser::parse(&input).unwrap(),
+        Packet::ReadParam(lxp::packet::ReadParam {
+            datalog: datalog(),
+            register: 0,
+            values: vec![44, 1]
+        })
+    );
+}
+
+#[test]
 fn build_write_param() {
     // this isn't hooked up yet anyway, no way to make a WriteParam packet from MQTT
+    // not even sure if this is right.. 2 bytes of register, 2 bytes len, then x bytes of values?
     let packet = Packet::WriteParam(lxp::packet::WriteParam {
         datalog: datalog(),
         register: 7,
@@ -233,12 +264,16 @@ fn build_write_param() {
 
     assert_eq!(
         lxp::packet::TcpFrameFactory::build(&packet),
-        vec![161, 26, 2, 0, 15, 0, 1, 196, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 7, 0, 3,]
+        vec![
+            161, 26, 2, 0, 18, 0, 1, 196, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 7, 0, 2, 0, 0, 3
+        ]
     );
 }
 
 #[test]
 fn parse_write_param_reply() {
+    // I guess this means that the inverter wrote 3 registers starting at 7?
+    // not sure if it's register 7, 0 then 3,   or register 7, then 0, 3
     let input = [
         161, 26, 2, 0, 15, 0, 1, 196, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 7, 0, 3,
     ];


### PR DESCRIPTION
Not sure what they really do. Just ignoring them for now to avoid lxp-bridge exiting every time it sees one.

Fixes #87