### PR TITLE
fix(ha): point HA discovery configs to `all`

### DIFF
--- a/src/home_assistant.rs
+++ b/src/home_assistant.rs
@@ -19,90 +19,80 @@ impl Config {
         mqtt_config: &config::Mqtt,
     ) -> Result<Vec<mqtt::Message>> {
         let r = vec![
-            Self::battery(inverter, mqtt_config, "soc", "Battery Percentage", 1)?,
-            Self::voltage(inverter, mqtt_config, "v_pv", "Voltage (PV Array)", 1)?,
-            Self::voltage(inverter, mqtt_config, "v_pv_1", "Voltage (PV String 1)", 1)?,
-            Self::voltage(inverter, mqtt_config, "v_pv_2", "Voltage (PV String 2)", 1)?,
-            Self::voltage(inverter, mqtt_config, "v_pv_3", "Voltage (PV String 3)", 1)?,
-            Self::voltage(inverter, mqtt_config, "v_bat", "Battery Voltage", 1)?,
-            Self::power(inverter, mqtt_config, "p_pv", "Power (PV Array)", 1)?,
-            Self::power(inverter, mqtt_config, "p_pv_1", "Power (PV String 1)", 1)?,
-            Self::power(inverter, mqtt_config, "p_pv_2", "Power (PV String 2)", 1)?,
-            Self::power(inverter, mqtt_config, "p_pv_3", "Power (PV String 3)", 1)?,
-            Self::power(inverter, mqtt_config, "p_charge", "Battery Charge", 1)?,
-            Self::power(inverter, mqtt_config, "p_discharge", "Battery Discharge", 1)?,
-            Self::power(inverter, mqtt_config, "p_to_user", "Power from Grid", 1)?,
-            Self::power(inverter, mqtt_config, "p_to_grid", "Power to Grid", 1)?,
+            Self::battery(inverter, mqtt_config, "soc", "Battery Percentage")?,
+            Self::voltage(inverter, mqtt_config, "v_pv", "Voltage (PV Array)")?,
+            Self::voltage(inverter, mqtt_config, "v_pv_1", "Voltage (PV String 1)")?,
+            Self::voltage(inverter, mqtt_config, "v_pv_2", "Voltage (PV String 2)")?,
+            Self::voltage(inverter, mqtt_config, "v_pv_3", "Voltage (PV String 3)")?,
+            Self::voltage(inverter, mqtt_config, "v_bat", "Battery Voltage")?,
+            Self::power(inverter, mqtt_config, "p_pv", "Power (PV Array)")?,
+            Self::power(inverter, mqtt_config, "p_pv_1", "Power (PV String 1)")?,
+            Self::power(inverter, mqtt_config, "p_pv_2", "Power (PV String 2)")?,
+            Self::power(inverter, mqtt_config, "p_pv_3", "Power (PV String 3)")?,
+            Self::power(inverter, mqtt_config, "p_charge", "Battery Charge")?,
+            Self::power(inverter, mqtt_config, "p_discharge", "Battery Discharge")?,
+            Self::power(inverter, mqtt_config, "p_to_user", "Power from Grid")?,
+            Self::power(inverter, mqtt_config, "p_to_grid", "Power to Grid")?,
             Self::energy(
                 inverter,
                 mqtt_config,
                 "e_pv_all",
                 "PV Generation (All time)",
-                2,
             )?,
             Self::energy(
                 inverter,
                 mqtt_config,
                 "e_pv_all_1",
                 "PV Generation (All time) (String 1)",
-                2,
             )?,
             Self::energy(
                 inverter,
                 mqtt_config,
                 "e_pv_all_2",
                 "PV Generation (All time) (String 2)",
-                2,
             )?,
             Self::energy(
                 inverter,
                 mqtt_config,
                 "e_pv_all_3",
                 "PV Generation (All time) (String 3)",
-                2,
             )?,
             Self::energy(
                 inverter,
                 mqtt_config,
                 "e_chg_all",
                 "Battery Charge (All time)",
-                2,
             )?,
             Self::energy(
                 inverter,
                 mqtt_config,
                 "e_dischg_all",
                 "Battery Discharge (All time)",
-                2,
             )?,
             Self::energy(
                 inverter,
                 mqtt_config,
                 "e_to_user_all",
                 "Energy from Grid (All time)",
-                2,
             )?,
             Self::energy(
                 inverter,
                 mqtt_config,
                 "e_to_grid_all",
                 "Energy to Grid (All time)",
-                2,
             )?,
-            Self::temperature(inverter, mqtt_config, "t_inner", "Inverter Temperature", 2)?,
+            Self::temperature(inverter, mqtt_config, "t_inner", "Inverter Temperature")?,
             Self::temperature(
                 inverter,
                 mqtt_config,
                 "t_rad_1",
                 "Radiator 1 Temperature",
-                2,
             )?,
             Self::temperature(
                 inverter,
                 mqtt_config,
                 "t_rad_2",
                 "Radiator 2 Temperature",
-                2,
             )?,
         ];
 
@@ -115,7 +105,6 @@ impl Config {
         mqtt_config: &config::Mqtt,
         name: &str,
         label: &str,
-        input: u16,
     ) -> Result<Option<mqtt::Message>> {
         if !Self::sensor_enabled(&mqtt_config.homeassistant.sensors, name) {
             return Ok(None);
@@ -127,8 +116,8 @@ impl Config {
             unit_of_measurement: "%".to_owned(),
             value_template: format!("{{{{ value_json.{} }}}}", name),
             state_topic: format!(
-                "{}/{}/inputs/{}",
-                mqtt_config.namespace, inverter.datalog, input
+                "{}/{}/inputs/all",
+                mqtt_config.namespace, inverter.datalog
             ),
             unique_id: format!("lxp_{}_{}", inverter.datalog, name),
             name: label.to_string(),
@@ -148,7 +137,6 @@ impl Config {
         mqtt_config: &config::Mqtt,
         name: &str,
         label: &str,
-        input: u16,
     ) -> Result<Option<mqtt::Message>> {
         if !Self::sensor_enabled(&mqtt_config.homeassistant.sensors, name) {
             return Ok(None);
@@ -160,8 +148,8 @@ impl Config {
             unit_of_measurement: "W".to_owned(),
             value_template: format!("{{{{ value_json.{} }}}}", name),
             state_topic: format!(
-                "{}/{}/inputs/{}",
-                mqtt_config.namespace, inverter.datalog, input
+                "{}/{}/inputs/all",
+                mqtt_config.namespace, inverter.datalog
             ),
             unique_id: format!("lxp_{}_{}", inverter.datalog, name),
             name: label.to_string(),
@@ -181,7 +169,6 @@ impl Config {
         mqtt_config: &config::Mqtt,
         name: &str,
         label: &str,
-        input: u16,
     ) -> Result<Option<mqtt::Message>> {
         if !Self::sensor_enabled(&mqtt_config.homeassistant.sensors, name) {
             return Ok(None);
@@ -193,8 +180,8 @@ impl Config {
             unit_of_measurement: "kWh".to_owned(),
             value_template: format!("{{{{ value_json.{} }}}}", name),
             state_topic: format!(
-                "{}/{}/inputs/{}",
-                mqtt_config.namespace, inverter.datalog, input
+                "{}/{}/inputs/all",
+                mqtt_config.namespace, inverter.datalog
             ),
             unique_id: format!("lxp_{}_{}", inverter.datalog, name),
             name: label.to_string(),
@@ -214,7 +201,6 @@ impl Config {
         mqtt_config: &config::Mqtt,
         name: &str,
         label: &str,
-        input: u16,
     ) -> Result<Option<mqtt::Message>> {
         if !Self::sensor_enabled(&mqtt_config.homeassistant.sensors, name) {
             return Ok(None);
@@ -226,8 +212,8 @@ impl Config {
             unit_of_measurement: "V".to_owned(),
             value_template: format!("{{{{ value_json.{} }}}}", name),
             state_topic: format!(
-                "{}/{}/inputs/{}",
-                mqtt_config.namespace, inverter.datalog, input
+                "{}/{}/inputs/all",
+                mqtt_config.namespace, inverter.datalog
             ),
             unique_id: format!("lxp_{}_{}", inverter.datalog, name),
             name: label.to_string(),
@@ -248,7 +234,6 @@ impl Config {
         mqtt_config: &config::Mqtt,
         name: &str,
         label: &str,
-        input: u16,
     ) -> Result<Option<mqtt::Message>> {
         if !Self::sensor_enabled(&mqtt_config.homeassistant.sensors, name) {
             return Ok(None);
@@ -260,8 +245,8 @@ impl Config {
             unit_of_measurement: "°C".to_owned(),
             value_template: format!("{{{{ value_json.{} }}}}", name),
             state_topic: format!(
-                "{}/{}/inputs/{}",
-                mqtt_config.namespace, inverter.datalog, input
+                "{}/{}/inputs/all",
+                mqtt_config.namespace, inverter.datalog
             ),
             unique_id: format!("lxp_{}_{}", inverter.datalog, name),
             name: label.to_string(),


### PR DESCRIPTION
The `all` MQTT topic contains all known read-only registers. At the same time, some inverter models (e.g. SNA) don't actually send the extra packets containing the necessary data.

For broader compatibility the Home Assistant discovery configs should simply point to the `all` topic to fetch any of the values.

Fixes #96.