### PR TITLE
changed startup to use tokio::main and added SIGINT/SIGTERM signal handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,6 +1831,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "similar"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,6 +2139,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde = { version = "~1 ", features = ["derive"] }
 serde_with = "~2"
 serde_json = "~1"
 serde_yaml = "~0.9"
-tokio = { version = "~1", features = ["net"] }
+tokio = { version = "~1", features = ["net", "macros", "signal"] }
 tokio-util = { version = "~0.7", features = ["codec"] }
 chrono = "~0.4"
 cron-parser = "~0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,17 +17,7 @@ const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 use crate::prelude::*;
 
-pub fn main() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let future = app();
-
-    if let Err(err) = rt.block_on(future) {
-        error!("{:?}", err);
-        std::process::exit(255);
-    }
-}
-
-async fn app() -> Result<()> {
+pub async fn app() -> Result<()> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug"))
         .format(|buf, record| {
             writeln!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,36 @@
-fn main() {
-    lxp_bridge::main()
+use anyhow::Result;
+use log::{error, info};
+use tokio::signal::unix::{signal, SignalKind};
+
+#[tokio::main]
+async fn main() {
+    tokio::select! {
+        result = lxp_bridge::app() => {
+            if let Err(err) = result {
+                error!("{:?}", err);
+                std::process::exit(255);
+            }
+        }
+        _ = cancel_on_int_or_term() => {
+        }
+    }
+}
+
+/// Provides a future that will terminate once a SIGINT or SIGTERM is
+/// received from the host. Allows the process to be terminated
+/// cleanly when running in a container (particularly Kubernetes).
+async fn cancel_on_int_or_term() -> Result<()> {
+    let mut sigterm = signal(SignalKind::terminate())?;
+    let mut sigint = signal(SignalKind::interrupt())?;
+
+    tokio::select! {
+        _ = sigterm.recv() => {
+            info!("Received SIGTERM, stopping process");
+        },
+        _ = sigint.recv() => {
+            info!("Received SIGINT, stopping process");
+        },
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
Changed to using `tokio::main` for async program execution.

THe `tokio::select!` macro terminates all tasks should one fail - this allows the task that waits for a `SIGINT` or `SIGTERM` to take down the main process. this allows k8s to cleanly terminate the pod.