### PR TITLE
Remove Windows build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -139,9 +139,6 @@ jobs:
         - build: darwin-arm64
           os: macos-11
           target: aarch64-apple-darwin
-        - build: windows-amd64.exe
-          os: windows-2019
-          target: x86_64-pc-windows-msvc
 
     steps:
       - uses: actions/checkout@v2
@@ -189,14 +186,8 @@ jobs:
           args: --release --target ${{ matrix.target }}
 
       - name: Rename release binary
-        if: runner.os != 'Windows'
         run: |
           mv target/${{ matrix.target }}/release/lxp-bridge lxp-bridge.${{ matrix.build }}
-
-      - name: Rename release binary
-        if: runner.os == 'Windows'
-        run: |
-          mv target/${{ matrix.target }}/release/lxp-bridge.exe lxp-bridge.${{ matrix.build }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,9 +71,6 @@ jobs:
         - build: darwin-arm64
           os: macos-11
           target: aarch64-apple-darwin
-        - build: windows-amd64.exe
-          os: windows-2019
-          target: x86_64-pc-windows-msvc
 
     steps:
       - uses: actions/checkout@v2
@@ -121,14 +118,8 @@ jobs:
           args: --release --target ${{ matrix.target }}
 
       - name: Rename release binary
-        if: runner.os != 'Windows'
         run: |
           mv target/${{ matrix.target }}/release/lxp-bridge lxp-bridge.${{ matrix.build }}
-
-      - name: Rename release binary
-        if: runner.os == 'Windows'
-        run: |
-          mv target/${{ matrix.target }}/release/lxp-bridge.exe lxp-bridge.${{ matrix.build }}
 
       - name: Set release version
         shell: bash
@@ -142,12 +133,8 @@ jobs:
           staging="lxp-bridge-${{ env.RELEASE_VERSION }}-${{ matrix.target }}"
           mkdir -p "$staging"
           cp "config.yaml.example" "$staging/"
-          if [ "${{ matrix.os }}" = "windows-2019" ]; then
-            cp "target/${{ matrix.target }}/release/lxp-bridge.exe" "$staging/"
-          else
-            cp "target/${{ matrix.target }}/release/lxp-bridge" "$staging/"
-            strip "$staging/lxp-bridge" || true
-          fi
+          cp "target/${{ matrix.target }}/release/lxp-bridge" "$staging/"
+          strip "$staging/lxp-bridge" || true
           7z a "$staging.zip" "$staging"
           echo "ASSET=$staging.zip" >> $GITHUB_ENV
 


### PR DESCRIPTION
This is easier than fixing the new signal handling and frankly I doubt anyone uses it.

Docker images are available now and we should be encouraging use of those over prebuilt binaries anyway.