### PR TITLE
Add a new scheduled read_inputs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,36 +9,6 @@ on:
     - master
 
 jobs:
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-
-      - uses: Swatinem/rust-cache@v1
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features=mocks
-        env:
-          CARGO_INCREMENTAL: '0'
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-
-      - uses: actions-rs/grcov@v0.1
-        id: coverage
-
-      - uses: codecov/codecov-action@v2
-        with:
-          file: ${{ steps.coverage.outputs.report }}
-          verbose: true # optional (default = false)
-
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Second attempt at ignoring unknown ReadInputs registers (#95)
 * Update HA discovery to use newer "all" MQTT message (#98, @excieve)
 * Exit on receipt of SIGTERM or SIGINT (#99, @kaitlinsm)
+* Add read_inputs scheduled task (#104)
 
 
 # 0.8.0 - 1st September 2022

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -40,3 +40,6 @@ scheduler:
   timesync:
     enabled: false
     cron: "0 0 * * *"
+  read_inputs:
+    enabled: false
+    cron: "*/5 * * * *"

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,8 +95,8 @@ pub struct Scheduler {
     #[serde(default = "Config::default_enabled")]
     pub enabled: bool,
 
-    pub timesync: Crontab,
-    pub read_inputs: Crontab,
+    pub timesync: Option<Crontab>,
+    pub read_inputs: Option<Crontab>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,6 +96,7 @@ pub struct Scheduler {
     pub enabled: bool,
 
     pub timesync: Crontab,
+    pub read_inputs: Crontab,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -52,4 +52,28 @@ impl Scheduler {
 
         Ok(())
     }
+
+    async fn read_inputs(&self) -> Result<()> {
+        info!("read_inputs starting");
+
+        let inverters = self.config.enabled_inverters().cloned();
+        let pairs = [(0, 40), (40, 40), (80, 40)];
+
+        for inverter in inverters {
+            for (register, count) in pairs {
+                coordinator::commands::read_inputs::ReadInputs::new(
+                    self.channels.clone(),
+                    inverter.clone(),
+                    register as u16,
+                    count,
+                )
+                .run()
+                .await?;
+            }
+        }
+
+        info!("read_inputs complete");
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Turns out that if you never connect the inverter to Luxpower then it might not transmit data, and we're not quite sure how to enable it being sent automatically.

As a stopgap, scheduling the requests for inputs data will do for now.

See #103 