### PR TITLE
Support replying to inverter heartbeats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Second attempt at ignoring unknown ReadInputs registers (#95)
 * Update HA discovery to use newer "all" MQTT message (#98, @excieve)
 * Exit on receipt of SIGTERM or SIGINT (#99, @kaitlinsm)
+* Add support for replying to inverter heartbeats (#106)
 
 
 # 0.8.0 - 1st September 2022

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -4,11 +4,13 @@ inverters:
   port: 8000
   serial: 5555555555
   datalog: 2222222222
+  heartbeats: false
 - enabled: false
   host: 192.168.0.163
   port: 8000
   serial: 9999999999
   datalog: 3333333333
+  heartbeats: false
 
 databases:
 - enabled: false

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,8 @@ pub struct Inverter {
     pub serial: Serial,
     #[serde(deserialize_with = "de_serial")]
     pub datalog: Serial,
+
+    pub heartbeats: Option<bool>,
 }
 
 fn de_serial<'de, D>(deserializer: D) -> Result<Serial, D::Error>

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -656,7 +656,7 @@ impl PacketCommon for Heartbeat {
     }
 
     fn bytes(&self) -> Vec<u8> {
-        Vec::new()
+        vec![0]
     }
 }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -17,6 +17,7 @@ impl Factory {
             host: "localhost".to_owned(),
             datalog: Serial::from_str("2222222222").unwrap(),
             serial: Serial::from_str("5555555555").unwrap(),
+            heartbeats: None,
         }
     }
 

--- a/tests/test_config.rs
+++ b/tests/test_config.rs
@@ -70,6 +70,7 @@ fn enabled_inverters() {
             host: "localhost".to_owned(),
             port: 8000,
             serial: example_serial(),
+            heartbeats: None,
         },
         config::Inverter {
             enabled: true,
@@ -77,6 +78,7 @@ fn enabled_inverters() {
             host: "localhost".to_owned(),
             port: 8000,
             serial: example_serial(),
+            heartbeats: None,
         },
     ];
 
@@ -95,6 +97,7 @@ fn inverters_for_message() {
             host: "localhost".to_owned(),
             port: 8000,
             serial: example_serial(),
+            heartbeats: None,
         },
         config::Inverter {
             enabled: false,
@@ -102,6 +105,7 @@ fn inverters_for_message() {
             host: "localhost".to_owned(),
             port: 8000,
             serial: example_serial(),
+            heartbeats: None,
         },
     ];
 

--- a/tests/test_packet_tcp_frames.rs
+++ b/tests/test_packet_tcp_frames.rs
@@ -22,6 +22,16 @@ fn parse_heartbeat() {
 }
 
 #[test]
+fn build_heartbeat() {
+    let packet = Packet::Heartbeat(lxp::packet::Heartbeat { datalog: datalog() });
+
+    assert_eq!(
+        lxp::packet::TcpFrameFactory::build(&packet),
+        vec![161, 26, 2, 0, 13, 0, 1, 193, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 0]
+    );
+}
+
+#[test]
 fn build_read_hold() {
     let packet = Packet::TranslatedData(lxp::packet::TranslatedData {
         datalog: datalog(),


### PR DESCRIPTION
Support for inverters not connected to Luxpower servers, part of #103 

This adds a new optional configuration key, `inverter.heartbeats`, which, if set to true, will reply to heartbeat packets from the inverter. Normally if you're connected to Luxpower's servers, they do this for you, and the replies prompt the inverter to broadcast its input data.

However, if you're not connected to them, because your Internet is down, or Luxpower disappear off the face of the planet, then your inverter will suddenly stop sending the data you want to log.

Set this new configuration key to true and lxp-bridge will respond to the heartbeats which should prompt the inverter back into life.