### PR TITLE
Move config into Rc<RefCell<>> for interior mutability

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -22,26 +22,28 @@ impl Command {
         use Command::*;
 
         let rest = match self {
-            ReadInputs1(inverter) => format!("{}/read/inputs/1", inverter.datalog),
-            ReadInputs2(inverter) => format!("{}/read/inputs/2", inverter.datalog),
-            ReadInputs3(inverter) => format!("{}/read/inputs/3", inverter.datalog),
+            ReadInputs1(inverter) => format!("{}/read/inputs/1", inverter.datalog()),
+            ReadInputs2(inverter) => format!("{}/read/inputs/2", inverter.datalog()),
+            ReadInputs3(inverter) => format!("{}/read/inputs/3", inverter.datalog()),
             ReadHold(inverter, register, _) => {
-                format!("{}/read/hold/{}", inverter.datalog, register)
+                format!("{}/read/hold/{}", inverter.datalog(), register)
             }
             ReadParam(inverter, register) => {
-                format!("{}/read/param/{}", inverter.datalog, register)
+                format!("{}/read/param/{}", inverter.datalog(), register)
             }
-            SetHold(inverter, register, _) => format!("{}/set/hold/{}", inverter.datalog, register),
-            AcCharge(inverter, _) => format!("{}/set/ac_charge", inverter.datalog),
-            ForcedDischarge(inverter, _) => format!("{}/set/forced_discharge", inverter.datalog),
-            ChargeRate(inverter, _) => format!("{}/set/charge_rate_pct", inverter.datalog),
-            DischargeRate(inverter, _) => format!("{}/set/discharge_rate_pct", inverter.datalog),
-            AcChargeRate(inverter, _) => format!("{}/set/ac_charge_rate_pct", inverter.datalog),
+            SetHold(inverter, register, _) => {
+                format!("{}/set/hold/{}", inverter.datalog(), register)
+            }
+            AcCharge(inverter, _) => format!("{}/set/ac_charge", inverter.datalog()),
+            ForcedDischarge(inverter, _) => format!("{}/set/forced_discharge", inverter.datalog()),
+            ChargeRate(inverter, _) => format!("{}/set/charge_rate_pct", inverter.datalog()),
+            DischargeRate(inverter, _) => format!("{}/set/discharge_rate_pct", inverter.datalog()),
+            AcChargeRate(inverter, _) => format!("{}/set/ac_charge_rate_pct", inverter.datalog()),
             AcChargeSocLimit(inverter, _) => {
-                format!("{}/set/ac_charge_soc_limit_pct", inverter.datalog)
+                format!("{}/set/ac_charge_soc_limit_pct", inverter.datalog())
             }
             DischargeCutoffSocLimit(inverter, _) => {
-                format!("{}/set/discharge_cutoff_soc_limit_pct", inverter.datalog)
+                format!("{}/set/discharge_cutoff_soc_limit_pct", inverter.datalog())
             }
         };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,6 +80,7 @@ impl HomeAssistant {
     pub fn prefix(&self) -> &str {
         &self.prefix
     }
+
     pub fn sensors(&self) -> &Vec<String> {
         &self.sensors
     }
@@ -176,11 +177,6 @@ pub struct Database {
     pub url: String,
 }
 impl Database {
-    pub fn new(enabled: bool, url: String) -> Self {
-        // used in tests
-        Self { enabled, url }
-    }
-
     pub fn enabled(&self) -> bool {
         self.enabled
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -226,6 +226,7 @@ impl Crontab {
     }
 } // }}}
 
+#[derive(Debug)]
 pub struct ConfigWrapper {
     config: Rc<RefCell<Config>>,
 }
@@ -306,6 +307,7 @@ impl ConfigWrapper {
         let mut c = self.config.borrow_mut();
         c.databases = new;
     }
+
     pub fn databases_mut(&self) -> RefMut<Vec<Database>> {
         RefMut::map(self.config.borrow_mut(), |b: &mut Config| &mut b.databases)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -180,11 +180,8 @@ impl ConfigWrapper {
         RefMut::map(self.config.borrow_mut(), |b: &mut Config| &mut b.databases)
     }
 
-    pub fn enabled_database_count(&self) -> usize {
-        self.databases()
-            .iter()
-            .filter(|database| database.enabled)
-            .count()
+    pub fn have_enabled_database(&self) -> bool {
+        self.databases().iter().any(|database| database.enabled)
     }
 
     pub fn enabled_databases(&self) -> Vec<Database> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,12 +45,12 @@ impl Inverter {
         self.port
     }
 
-    pub fn serial(&self) -> &Serial {
-        &self.serial
+    pub fn serial(&self) -> Serial {
+        self.serial
     }
 
-    pub fn datalog(&self) -> &Serial {
-        &self.datalog
+    pub fn datalog(&self) -> Serial {
+        self.datalog
     }
 
     pub fn heartbeats(&self) -> bool {

--- a/src/coordinator/commands/read_hold.rs
+++ b/src/coordinator/commands/read_hold.rs
@@ -27,9 +27,9 @@ impl ReadHold {
 
     pub async fn run(&self) -> Result<Packet> {
         let packet = Packet::TranslatedData(TranslatedData {
-            datalog: self.inverter.datalog,
+            datalog: *self.inverter.datalog(),
             device_function: DeviceFunction::ReadHold,
-            inverter: self.inverter.serial,
+            inverter: *self.inverter.serial(),
             register: self.register,
             values: self.count.to_le_bytes().to_vec(),
         });

--- a/src/coordinator/commands/read_hold.rs
+++ b/src/coordinator/commands/read_hold.rs
@@ -27,9 +27,9 @@ impl ReadHold {
 
     pub async fn run(&self) -> Result<Packet> {
         let packet = Packet::TranslatedData(TranslatedData {
-            datalog: *self.inverter.datalog(),
+            datalog: self.inverter.datalog(),
             device_function: DeviceFunction::ReadHold,
-            inverter: *self.inverter.serial(),
+            inverter: self.inverter.serial(),
             register: self.register,
             values: self.count.to_le_bytes().to_vec(),
         });

--- a/src/coordinator/commands/read_inputs.rs
+++ b/src/coordinator/commands/read_inputs.rs
@@ -27,9 +27,9 @@ impl ReadInputs {
 
     pub async fn run(&self) -> Result<Packet> {
         let packet = Packet::TranslatedData(TranslatedData {
-            datalog: self.inverter.datalog,
+            datalog: *self.inverter.datalog(),
             device_function: DeviceFunction::ReadInput,
-            inverter: self.inverter.serial,
+            inverter: *self.inverter.serial(),
             register: self.register,
             values: self.count.to_le_bytes().to_vec(),
         });

--- a/src/coordinator/commands/read_inputs.rs
+++ b/src/coordinator/commands/read_inputs.rs
@@ -27,9 +27,9 @@ impl ReadInputs {
 
     pub async fn run(&self) -> Result<Packet> {
         let packet = Packet::TranslatedData(TranslatedData {
-            datalog: *self.inverter.datalog(),
+            datalog: self.inverter.datalog(),
             device_function: DeviceFunction::ReadInput,
-            inverter: *self.inverter.serial(),
+            inverter: self.inverter.serial(),
             register: self.register,
             values: self.count.to_le_bytes().to_vec(),
         });

--- a/src/coordinator/commands/read_param.rs
+++ b/src/coordinator/commands/read_param.rs
@@ -22,7 +22,7 @@ impl ReadParam {
 
     pub async fn run(&self) -> Result<Packet> {
         let packet = Packet::ReadParam(lxp::packet::ReadParam {
-            datalog: *self.inverter.datalog(),
+            datalog: self.inverter.datalog(),
             register: self.register,
             values: vec![], // unused
         });

--- a/src/coordinator/commands/read_param.rs
+++ b/src/coordinator/commands/read_param.rs
@@ -22,7 +22,7 @@ impl ReadParam {
 
     pub async fn run(&self) -> Result<Packet> {
         let packet = Packet::ReadParam(lxp::packet::ReadParam {
-            datalog: self.inverter.datalog,
+            datalog: *self.inverter.datalog(),
             register: self.register,
             values: vec![], // unused
         });

--- a/src/coordinator/commands/set_hold.rs
+++ b/src/coordinator/commands/set_hold.rs
@@ -27,9 +27,9 @@ impl SetHold {
 
     pub async fn run(&self) -> Result<Packet> {
         let packet = Packet::TranslatedData(TranslatedData {
-            datalog: *self.inverter.datalog(),
+            datalog: self.inverter.datalog(),
             device_function: DeviceFunction::WriteSingle,
-            inverter: *self.inverter.serial(),
+            inverter: self.inverter.serial(),
             register: self.register,
             values: self.value.to_le_bytes().to_vec(),
         });

--- a/src/coordinator/commands/set_hold.rs
+++ b/src/coordinator/commands/set_hold.rs
@@ -27,9 +27,9 @@ impl SetHold {
 
     pub async fn run(&self) -> Result<Packet> {
         let packet = Packet::TranslatedData(TranslatedData {
-            datalog: self.inverter.datalog,
+            datalog: *self.inverter.datalog(),
             device_function: DeviceFunction::WriteSingle,
-            inverter: self.inverter.serial,
+            inverter: *self.inverter.serial(),
             register: self.register,
             values: self.value.to_le_bytes().to_vec(),
         });

--- a/src/coordinator/commands/timesync.rs
+++ b/src/coordinator/commands/timesync.rs
@@ -19,9 +19,9 @@ impl TimeSync {
 
     pub async fn run(&self) -> Result<()> {
         let packet = Packet::TranslatedData(TranslatedData {
-            datalog: *self.inverter.datalog(),
+            datalog: self.inverter.datalog(),
             device_function: DeviceFunction::ReadHold,
-            inverter: *self.inverter.serial(),
+            inverter: self.inverter.serial(),
             register: 12,
             values: vec![3, 0],
         });
@@ -87,9 +87,9 @@ impl TimeSync {
         let now = Utils::localtime();
 
         Packet::TranslatedData(TranslatedData {
-            datalog: *self.inverter.datalog(),
+            datalog: self.inverter.datalog(),
             device_function: DeviceFunction::WriteMulti,
-            inverter: *self.inverter.serial(),
+            inverter: self.inverter.serial(),
             register: 12,
             values: vec![
                 (now.year() - 2000) as u8,

--- a/src/coordinator/commands/timesync.rs
+++ b/src/coordinator/commands/timesync.rs
@@ -19,9 +19,9 @@ impl TimeSync {
 
     pub async fn run(&self) -> Result<()> {
         let packet = Packet::TranslatedData(TranslatedData {
-            datalog: self.inverter.datalog,
+            datalog: *self.inverter.datalog(),
             device_function: DeviceFunction::ReadHold,
-            inverter: self.inverter.serial,
+            inverter: *self.inverter.serial(),
             register: 12,
             values: vec![3, 0],
         });
@@ -53,7 +53,7 @@ impl TimeSync {
 
             debug!(
                 "inverter {} time difference is {}",
-                self.inverter.datalog,
+                self.inverter.datalog(),
                 dt - now
             );
 
@@ -87,9 +87,9 @@ impl TimeSync {
         let now = Utils::localtime();
 
         Packet::TranslatedData(TranslatedData {
-            datalog: self.inverter.datalog,
+            datalog: *self.inverter.datalog(),
             device_function: DeviceFunction::WriteMulti,
-            inverter: self.inverter.serial,
+            inverter: *self.inverter.serial(),
             register: 12,
             values: vec![
                 (now.year() - 2000) as u8,

--- a/src/coordinator/commands/update_hold.rs
+++ b/src/coordinator/commands/update_hold.rs
@@ -38,9 +38,9 @@ impl UpdateHold {
 
         // get register from inverter
         let packet = Packet::TranslatedData(TranslatedData {
-            datalog: *self.inverter.datalog(),
+            datalog: self.inverter.datalog(),
             device_function: DeviceFunction::ReadHold,
-            inverter: *self.inverter.serial(),
+            inverter: self.inverter.serial(),
             register: self.register,
             values: vec![1, 0],
         });
@@ -65,9 +65,9 @@ impl UpdateHold {
         // new packet to set register with a new value
         let values = value.to_le_bytes().to_vec();
         let packet = Packet::TranslatedData(TranslatedData {
-            datalog: *self.inverter.datalog(),
+            datalog: self.inverter.datalog(),
             device_function: DeviceFunction::WriteSingle,
-            inverter: *self.inverter.serial(),
+            inverter: self.inverter.serial(),
             register: self.register,
             values,
         });

--- a/src/coordinator/commands/update_hold.rs
+++ b/src/coordinator/commands/update_hold.rs
@@ -38,9 +38,9 @@ impl UpdateHold {
 
         // get register from inverter
         let packet = Packet::TranslatedData(TranslatedData {
-            datalog: self.inverter.datalog,
+            datalog: *self.inverter.datalog(),
             device_function: DeviceFunction::ReadHold,
-            inverter: self.inverter.serial,
+            inverter: *self.inverter.serial(),
             register: self.register,
             values: vec![1, 0],
         });
@@ -65,9 +65,9 @@ impl UpdateHold {
         // new packet to set register with a new value
         let values = value.to_le_bytes().to_vec();
         let packet = Packet::TranslatedData(TranslatedData {
-            datalog: self.inverter.datalog,
+            datalog: *self.inverter.datalog(),
             device_function: DeviceFunction::WriteSingle,
-            inverter: self.inverter.serial,
+            inverter: *self.inverter.serial(),
             register: self.register,
             values,
         });

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -13,19 +13,12 @@ pub type InputsStore = std::collections::HashMap<Serial, lxp::packet::ReadInputs
 
 pub struct Coordinator {
     config: ConfigWrapper,
-    have_enabled_databases: bool,
     channels: Channels,
 }
 
 impl Coordinator {
     pub fn new(config: ConfigWrapper, channels: Channels) -> Self {
-        let have_enabled_databases = config.enabled_database_count() > 0;
-
-        Self {
-            config,
-            have_enabled_databases,
-            channels,
-        }
+        Self { config, channels }
     }
 
     pub async fn start(&self) -> Result<()> {
@@ -331,7 +324,7 @@ impl Coordinator {
             }
         }
 
-        if self.have_enabled_databases {
+        if self.config.have_enabled_database() {
             let channel_data = database::ChannelData::ReadInputAll(input);
             if self.channels.to_database.send(channel_data).is_err() {
                 bail!("send(to_database) failed - channel closed?");

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -12,14 +12,14 @@ pub enum ChannelData {
 pub type InputsStore = std::collections::HashMap<Serial, lxp::packet::ReadInputs>;
 
 pub struct Coordinator {
-    config: Rc<Config>,
+    config: ConfigWrapper,
     have_enabled_databases: bool,
     channels: Channels,
 }
 
 impl Coordinator {
-    pub fn new(config: Rc<Config>, channels: Channels) -> Self {
-        let have_enabled_databases = config.enabled_databases().count() > 0;
+    pub fn new(config: ConfigWrapper, channels: Channels) -> Self {
+        let have_enabled_databases = config.enabled_database_count() > 0;
 
         Self {
             config,
@@ -283,7 +283,7 @@ impl Coordinator {
                         entry.set_read_input_3(r3);
 
                         if let Some(input) = entry.to_input_all() {
-                            if self.config.mqtt.enabled {
+                            if self.config.mqtt().enabled {
                                 let message = mqtt::Message::for_input_all(&input, datalog)?;
                                 let channel_data = mqtt::ChannelData::Message(message);
                                 if self.channels.to_mqtt.send(channel_data).is_err() {
@@ -299,7 +299,7 @@ impl Coordinator {
             }
         }
 
-        if self.config.mqtt.enabled {
+        if self.config.mqtt().enabled {
             // returns a Vec of messages to send. could be none;
             // not every packet produces an MQ message (eg, heartbeats),
             // and some produce >1 (multi-register ReadHold)
@@ -324,7 +324,7 @@ impl Coordinator {
     }
 
     async fn save_input_all(&self, input: Box<lxp::packet::ReadInputAll>) -> Result<()> {
-        if self.config.influx.enabled {
+        if self.config.influx().enabled {
             let channel_data = influx::ChannelData::InputData(serde_json::to_value(&input)?);
             if self.channels.to_influx.send(channel_data).is_err() {
                 bail!("send(to_influx) failed - channel closed?");

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -276,7 +276,7 @@ impl Coordinator {
                         entry.set_read_input_3(r3);
 
                         if let Some(input) = entry.to_input_all() {
-                            if self.config.mqtt().enabled {
+                            if self.config.mqtt().enabled() {
                                 let message = mqtt::Message::for_input_all(&input, datalog)?;
                                 let channel_data = mqtt::ChannelData::Message(message);
                                 if self.channels.to_mqtt.send(channel_data).is_err() {
@@ -292,7 +292,7 @@ impl Coordinator {
             }
         }
 
-        if self.config.mqtt().enabled {
+        if self.config.mqtt().enabled() {
             // returns a Vec of messages to send. could be none;
             // not every packet produces an MQ message (eg, heartbeats),
             // and some produce >1 (multi-register ReadHold)
@@ -317,7 +317,7 @@ impl Coordinator {
     }
 
     async fn save_input_all(&self, input: Box<lxp::packet::ReadInputAll>) -> Result<()> {
-        if self.config.influx().enabled {
+        if self.config.influx().enabled() {
             let channel_data = influx::ChannelData::InputData(serde_json::to_value(&input)?);
             if self.channels.to_influx.send(channel_data).is_err() {
                 bail!("send(to_influx) failed - channel closed?");

--- a/src/database.rs
+++ b/src/database.rs
@@ -48,17 +48,17 @@ impl Database {
     }
 
     fn database(&self) -> Result<DatabaseType> {
-        let prefix: Vec<&str> = self.config.url.splitn(2, ':').collect();
+        let prefix: Vec<&str> = self.config.url().splitn(2, ':').collect();
         match prefix[0] {
             "sqlite" => Ok(DatabaseType::SQLite),
             "mysql" => Ok(DatabaseType::MySQL),
             "postgres" => Ok(DatabaseType::Postgres),
-            _ => Err(anyhow!("unsupported database {}", self.config.url)),
+            _ => Err(anyhow!("unsupported database {}", self.config.url())),
         }
     }
 
     async fn connect(&self) -> Result<()> {
-        let mut options = AnyConnectOptions::from_str(&self.config.url)?;
+        let mut options = AnyConnectOptions::from_str(self.config.url())?;
         options.disable_statement_logging();
         let pool = sqlx::any::AnyPool::connect_with(options).await?;
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -24,6 +24,8 @@ pub struct Database {
 }
 
 impl Database {
+    // databases don't bother with a ConfigWrapper yet as they don't care about any
+    // changes once running; there's only enabled/url anyway and we'd use url to key off.
     pub fn new(config: config::Database, channels: Channels) -> Self {
         Self {
             config,

--- a/src/home_assistant.rs
+++ b/src/home_assistant.rs
@@ -82,18 +82,8 @@ impl Config {
                 "Energy to Grid (All time)",
             )?,
             Self::temperature(inverter, mqtt_config, "t_inner", "Inverter Temperature")?,
-            Self::temperature(
-                inverter,
-                mqtt_config,
-                "t_rad_1",
-                "Radiator 1 Temperature",
-            )?,
-            Self::temperature(
-                inverter,
-                mqtt_config,
-                "t_rad_2",
-                "Radiator 2 Temperature",
-            )?,
+            Self::temperature(inverter, mqtt_config, "t_rad_1", "Radiator 1 Temperature")?,
+            Self::temperature(inverter, mqtt_config, "t_rad_2", "Radiator 2 Temperature")?,
         ];
 
         // drop all None
@@ -106,7 +96,7 @@ impl Config {
         name: &str,
         label: &str,
     ) -> Result<Option<mqtt::Message>> {
-        if !Self::sensor_enabled(&mqtt_config.homeassistant.sensors, name) {
+        if !Self::sensor_enabled(mqtt_config.homeassistant().sensors(), name) {
             return Ok(None);
         }
 
@@ -117,16 +107,19 @@ impl Config {
             value_template: format!("{{{{ value_json.{} }}}}", name),
             state_topic: format!(
                 "{}/{}/inputs/all",
-                mqtt_config.namespace, inverter.datalog
+                mqtt_config.namespace(),
+                inverter.datalog()
             ),
-            unique_id: format!("lxp_{}_{}", inverter.datalog, name),
+            unique_id: format!("lxp_{}_{}", inverter.datalog(), name),
             name: label.to_string(),
         };
 
         Ok(Some(mqtt::Message {
             topic: format!(
                 "{}/sensor/{}_{}/config",
-                mqtt_config.homeassistant.prefix, inverter.datalog, name
+                mqtt_config.homeassistant().prefix(),
+                inverter.datalog(),
+                name
             ),
             payload: serde_json::to_string(&config)?,
         }))
@@ -138,7 +131,7 @@ impl Config {
         name: &str,
         label: &str,
     ) -> Result<Option<mqtt::Message>> {
-        if !Self::sensor_enabled(&mqtt_config.homeassistant.sensors, name) {
+        if !Self::sensor_enabled(mqtt_config.homeassistant().sensors(), name) {
             return Ok(None);
         }
 
@@ -149,16 +142,19 @@ impl Config {
             value_template: format!("{{{{ value_json.{} }}}}", name),
             state_topic: format!(
                 "{}/{}/inputs/all",
-                mqtt_config.namespace, inverter.datalog
+                mqtt_config.namespace(),
+                inverter.datalog()
             ),
-            unique_id: format!("lxp_{}_{}", inverter.datalog, name),
+            unique_id: format!("lxp_{}_{}", inverter.datalog(), name),
             name: label.to_string(),
         };
 
         Ok(Some(mqtt::Message {
             topic: format!(
                 "{}/sensor/{}_{}/config",
-                mqtt_config.homeassistant.prefix, inverter.datalog, name
+                mqtt_config.homeassistant().prefix(),
+                inverter.datalog(),
+                name
             ),
             payload: serde_json::to_string(&config)?,
         }))
@@ -170,7 +166,7 @@ impl Config {
         name: &str,
         label: &str,
     ) -> Result<Option<mqtt::Message>> {
-        if !Self::sensor_enabled(&mqtt_config.homeassistant.sensors, name) {
+        if !Self::sensor_enabled(mqtt_config.homeassistant().sensors(), name) {
             return Ok(None);
         }
 
@@ -181,16 +177,19 @@ impl Config {
             value_template: format!("{{{{ value_json.{} }}}}", name),
             state_topic: format!(
                 "{}/{}/inputs/all",
-                mqtt_config.namespace, inverter.datalog
+                mqtt_config.namespace(),
+                inverter.datalog()
             ),
-            unique_id: format!("lxp_{}_{}", inverter.datalog, name),
+            unique_id: format!("lxp_{}_{}", inverter.datalog(), name),
             name: label.to_string(),
         };
 
         Ok(Some(mqtt::Message {
             topic: format!(
                 "{}/sensor/{}_{}/config",
-                mqtt_config.homeassistant.prefix, inverter.datalog, name
+                mqtt_config.homeassistant().prefix(),
+                inverter.datalog(),
+                name
             ),
             payload: serde_json::to_string(&config)?,
         }))
@@ -202,7 +201,7 @@ impl Config {
         name: &str,
         label: &str,
     ) -> Result<Option<mqtt::Message>> {
-        if !Self::sensor_enabled(&mqtt_config.homeassistant.sensors, name) {
+        if !Self::sensor_enabled(mqtt_config.homeassistant().sensors(), name) {
             return Ok(None);
         }
 
@@ -213,16 +212,19 @@ impl Config {
             value_template: format!("{{{{ value_json.{} }}}}", name),
             state_topic: format!(
                 "{}/{}/inputs/all",
-                mqtt_config.namespace, inverter.datalog
+                mqtt_config.namespace(),
+                inverter.datalog()
             ),
-            unique_id: format!("lxp_{}_{}", inverter.datalog, name),
+            unique_id: format!("lxp_{}_{}", inverter.datalog(), name),
             name: label.to_string(),
         };
 
         Ok(Some(mqtt::Message {
             topic: format!(
                 "{}/sensor/{}_{}/config",
-                mqtt_config.homeassistant.prefix, inverter.datalog, name
+                mqtt_config.homeassistant().prefix(),
+                inverter.datalog(),
+                name
             ),
 
             payload: serde_json::to_string(&config)?,
@@ -235,7 +237,7 @@ impl Config {
         name: &str,
         label: &str,
     ) -> Result<Option<mqtt::Message>> {
-        if !Self::sensor_enabled(&mqtt_config.homeassistant.sensors, name) {
+        if !Self::sensor_enabled(mqtt_config.homeassistant().sensors(), name) {
             return Ok(None);
         }
 
@@ -246,16 +248,19 @@ impl Config {
             value_template: format!("{{{{ value_json.{} }}}}", name),
             state_topic: format!(
                 "{}/{}/inputs/all",
-                mqtt_config.namespace, inverter.datalog
+                mqtt_config.namespace(),
+                inverter.datalog()
             ),
-            unique_id: format!("lxp_{}_{}", inverter.datalog, name),
+            unique_id: format!("lxp_{}_{}", inverter.datalog(), name),
             name: label.to_string(),
         };
 
         Ok(Some(mqtt::Message {
             topic: format!(
                 "{}/sensor/{}_{}/config",
-                mqtt_config.homeassistant.prefix, inverter.datalog, name
+                mqtt_config.homeassistant().prefix(),
+                inverter.datalog(),
+                name
             ),
             payload: serde_json::to_string(&config)?,
         }))

--- a/src/influx.rs
+++ b/src/influx.rs
@@ -24,17 +24,17 @@ impl Influx {
     }
 
     pub async fn start(&self) -> Result<()> {
-        if !&self.config.influx().enabled {
+        if !self.config.influx().enabled() {
             info!("influx disabled, skipping");
             return Ok(());
         }
 
-        info!("initializing influx at {}", self.config.influx().url);
+        info!("initializing influx at {}", self.config.influx().url());
 
         let client = {
             let config = self.config.influx();
-            let url = reqwest::Url::parse(&config.url)?;
-            let credentials = match (&config.username, &config.password) {
+            let url = reqwest::Url::parse(config.url())?;
+            let credentials = match (config.username(), config.password()) {
                 (Some(u), Some(p)) => Some((u, p)),
                 _ => None,
             };
@@ -95,6 +95,6 @@ impl Influx {
     }
 
     fn database(&self) -> String {
-        self.config.influx().database.clone()
+        self.config.influx().database().to_string()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub async fn app() -> Result<()> {
     let inverters = config
         .enabled_inverters()
         .into_iter()
-        .map(|inverter| Inverter::new(inverter, channels.clone()))
+        .map(|inverter| Inverter::new(config.clone(), &inverter, channels.clone()))
         .collect();
 
     let databases = config

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,24 +36,24 @@ pub async fn app() -> Result<()> {
 
     info!("lxp-bridge {} starting", CARGO_PKG_VERSION);
 
-    let config = Rc::new(Config::new(options.config_file)?);
+    let config = ConfigWrapper::new(options.config_file)?;
 
     let channels = Channels::new();
 
-    let scheduler = Scheduler::new(Rc::clone(&config), channels.clone());
-    let mqtt = Mqtt::new(Rc::clone(&config), channels.clone());
-    let influx = Influx::new(Rc::clone(&config), channels.clone());
-    let coordinator = Coordinator::new(Rc::clone(&config), channels.clone());
+    let scheduler = Scheduler::new(config.clone(), channels.clone());
+    let mqtt = Mqtt::new(config.clone(), channels.clone());
+    let influx = Influx::new(config.clone(), channels.clone());
+    let coordinator = Coordinator::new(config.clone(), channels.clone());
 
     let inverters = config
         .enabled_inverters()
-        .cloned()
+        .into_iter()
         .map(|inverter| Inverter::new(inverter, channels.clone()))
         .collect();
 
     let databases = config
         .enabled_databases()
-        .cloned()
+        .into_iter()
         .map(|database| Database::new(database, channels.clone()))
         .collect();
 

--- a/src/lxp/inverter.rs
+++ b/src/lxp/inverter.rs
@@ -151,7 +151,7 @@ impl Inverter {
             info!("inverter {}: reconnecting in 5s", self.config().datalog());
             self.channels
                 .from_inverter
-                .send(ChannelData::Disconnect(*self.config().datalog()))?; // kill any waiting readers
+                .send(ChannelData::Disconnect(self.config().datalog()))?; // kill any waiting readers
             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
         }
 
@@ -257,7 +257,7 @@ impl Inverter {
                     // never complete. ideally we need to pass the fixed packet back?
                     //self.fix_outgoing_packet_serials(&mut packet);
 
-                    if packet.datalog() == *self.config().datalog() {
+                    if packet.datalog() == self.config().datalog() {
                         //debug!("inverter {}: TX {:?}", self.config.datalog, packet);
                         let bytes = lxp::packet::TcpFrameFactory::build(&packet);
                         debug!("inverter {}: TX {:?}", self.config().datalog(), bytes);
@@ -299,7 +299,7 @@ impl Inverter {
     */
 
     fn compare_datalog(&self, packet: Serial) {
-        if packet != *self.config().datalog() {
+        if packet != self.config().datalog() {
             warn!(
                 "datalog serial mismatch found; packet={}, config={} - please check config!",
                 packet,
@@ -311,7 +311,7 @@ impl Inverter {
     }
 
     fn compare_inverter(&self, packet: Serial) {
-        if packet != *self.config().serial() {
+        if packet != self.config().serial() {
             warn!(
                 "inverter serial mismatch found; packet={}, config={} - please check config!",
                 packet,

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -167,13 +167,13 @@ pub enum ChannelData {
 pub type Sender = broadcast::Sender<ChannelData>;
 
 pub struct Mqtt {
-    config: Rc<Config>,
+    config: ConfigWrapper,
     shutdown: bool,
     channels: Channels,
 }
 
 impl Mqtt {
-    pub fn new(config: Rc<Config>, channels: Channels) -> Self {
+    pub fn new(config: ConfigWrapper, channels: Channels) -> Self {
         Self {
             config,
             channels,
@@ -182,21 +182,21 @@ impl Mqtt {
     }
 
     pub async fn start(&self) -> Result<()> {
-        let m = &self.config.mqtt;
+        let c = &self.config;
 
-        if !m.enabled {
+        if !c.mqtt().enabled {
             info!("mqtt disabled, skipping");
             return Ok(());
         }
 
-        let mut options = MqttOptions::new("lxp-bridge2", &m.host, m.port);
+        let mut options = MqttOptions::new("lxp-bridge", &c.mqtt().host, c.mqtt().port);
 
         options.set_keep_alive(std::time::Duration::from_secs(60));
-        if let (Some(u), Some(p)) = (&m.username, &m.password) {
+        if let (Some(u), Some(p)) = (&c.mqtt().username, &c.mqtt().password) {
             options.set_credentials(u, p);
         }
 
-        info!("initializing mqtt at {}:{}", &m.host, m.port);
+        info!("initializing mqtt at {}:{}", &c.mqtt().host, c.mqtt().port);
 
         let (client, eventloop) = AsyncClient::new(options, 10);
 
@@ -218,7 +218,7 @@ impl Mqtt {
     async fn setup(&self, client: AsyncClient) -> Result<()> {
         client
             .subscribe(
-                format!("{}/cmd/all/#", self.config.mqtt.namespace),
+                format!("{}/cmd/all/#", self.config.mqtt().namespace),
                 QoS::AtMostOnce,
             )
             .await?;
@@ -226,13 +226,17 @@ impl Mqtt {
         for inverter in self.config.enabled_inverters() {
             client
                 .subscribe(
-                    format!("{}/cmd/{}/#", self.config.mqtt.namespace, inverter.datalog),
+                    format!(
+                        "{}/cmd/{}/#",
+                        self.config.mqtt().namespace,
+                        inverter.datalog
+                    ),
                     QoS::AtMostOnce,
                 )
                 .await?;
 
-            if self.config.mqtt.homeassistant.enabled {
-                let msgs = home_assistant::Config::all(inverter, &self.config.mqtt)?;
+            if self.config.mqtt().homeassistant.enabled {
+                let msgs = home_assistant::Config::all(&inverter, &self.config.mqtt())?;
                 for msg in msgs.into_iter() {
                     let _ = client
                         .publish(&msg.topic, QoS::AtLeastOnce, true, msg.payload)
@@ -277,7 +281,7 @@ impl Mqtt {
     fn handle_message(&self, publish: Publish) -> Result<()> {
         // remove the namespace, including the first /
         // doing it this way means we don't break if namespace happens to contain a /
-        let topic = publish.topic[self.config.mqtt.namespace.len() + 1..].to_owned();
+        let topic = publish.topic[self.config.mqtt().namespace.len() + 1..].to_owned();
 
         let message = Message {
             topic,
@@ -306,7 +310,7 @@ impl Mqtt {
             match receiver.recv().await? {
                 Shutdown => break,
                 Message(message) => {
-                    let topic = format!("{}/{}", self.config.mqtt.namespace, message.topic);
+                    let topic = format!("{}/{}", self.config.mqtt().namespace, message.topic);
                     info!("publishing: {} = {}", topic, message.payload);
                     let _ = client
                         .publish(&topic, QoS::AtLeastOnce, false, message.payload)

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,5 @@
 pub use std::{
-    cell::RefCell,
+    cell::{Ref, RefCell, RefMut},
     convert::{TryFrom, TryInto},
     io::Write,
     rc::Rc,
@@ -15,7 +15,7 @@ pub use {
 pub use crate::{
     channels::Channels,
     command::Command,
-    config::{self, Config},
+    config::{self, Config, ConfigWrapper},
     coordinator::{self, Coordinator},
     database::{self, Database},
     home_assistant,

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -22,16 +22,16 @@ impl Scheduler {
         }
 
         let scheduler = scheduler.unwrap();
-        if !scheduler.enabled {
+        if !scheduler.enabled() {
             info!("scheduler disabled, skipping");
             return Ok(());
         }
 
         info!("scheduler starting");
 
-        if scheduler.timesync.enabled {
+        if scheduler.timesync().enabled() {
             // sticking to Utc here avoids some "invalid date" panics around DST changes
-            while let Ok(next) = parse(&scheduler.timesync.cron, &Utils::utc()) {
+            while let Ok(next) = parse(scheduler.timesync().cron(), &Utils::utc()) {
                 let sleep = next - Utils::utc();
 
                 // localtime is only used for display

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -10,6 +10,10 @@ impl Factory {
         Config::new("config.yaml.example".to_owned()).unwrap()
     }
 
+    pub fn example_config_wrapped() -> config::ConfigWrapper {
+        ConfigWrapper::new("config.yaml.example".to_owned()).unwrap()
+    }
+
     pub fn inverter() -> config::Inverter {
         config::Inverter {
             enabled: true,

--- a/tests/test_config.rs
+++ b/tests/test_config.rs
@@ -72,9 +72,9 @@ fn homeassistant_sensors_parsing() {
 
 #[test]
 fn enabled_inverters() {
-    let mut config = Factory::example_config();
+    let config = Factory::example_config_wrapped();
 
-    config.inverters = vec![
+    config.set_inverters(vec![
         config::Inverter {
             enabled: false,
             datalog: example_serial(),
@@ -91,17 +91,16 @@ fn enabled_inverters() {
             serial: example_serial(),
             heartbeats: None,
         },
-    ];
+    ]);
 
-    let r: Vec<&config::Inverter> = config.enabled_inverters().collect();
-    assert_eq!(r.len(), 1);
+    assert_eq!(config.enabled_inverters().len(), 1);
 }
 
 #[test]
 fn inverters_for_message() {
-    let mut config = Factory::example_config();
+    let config = Factory::example_config_wrapped();
 
-    config.inverters = vec![
+    config.set_inverters(vec![
         config::Inverter {
             enabled: true,
             datalog: example_serial(),
@@ -118,7 +117,7 @@ fn inverters_for_message() {
             serial: example_serial(),
             heartbeats: None,
         },
-    ];
+    ]);
 
     let message = mqtt::Message {
         topic: "cmd/all/foo".to_string(),
@@ -147,9 +146,9 @@ fn inverters_for_message() {
 
 #[test]
 fn enabled_databases() {
-    let mut config = Factory::example_config();
+    let config = Factory::example_config_wrapped();
 
-    config.databases = vec![
+    config.set_databases(vec![
         config::Database {
             enabled: false,
             url: "sqlite://test.db".to_owned(),
@@ -158,8 +157,7 @@ fn enabled_databases() {
             enabled: true,
             url: "sqlite://test.db".to_owned(),
         },
-    ];
+    ]);
 
-    let r: Vec<&config::Database> = config.enabled_databases().collect();
-    assert_eq!(r.len(), 1);
+    assert_eq!(config.enabled_databases().len(), 1);
 }

--- a/tests/test_config.rs
+++ b/tests/test_config.rs
@@ -24,50 +24,50 @@ fn inverter_defaults() {
     let input =
         json!({ "host": "host", "port": 8000, "serial": "TESTSERIAL", "datalog": "TESTDATALO" });
     let inverter: config::Inverter = serde_json::from_value(input).unwrap();
-    assert!(inverter.enabled);
-    assert_eq!(inverter.heartbeats, None);
+    assert!(inverter.enabled());
+    assert_eq!(inverter.heartbeats(), false);
 }
 
 #[test]
 fn inverter_heartbeats() {
     let input = json!({ "host": "host", "port": 8000, "serial": "TESTSERIAL", "datalog": "TESTDATALO", "heartbeats": false });
     let inverter: config::Inverter = serde_json::from_value(input).unwrap();
-    assert_eq!(inverter.heartbeats, Some(false));
+    assert_eq!(inverter.heartbeats(), false);
     let input = json!({ "host": "host", "port": 8000, "serial": "TESTSERIAL", "datalog": "TESTDATALO", "heartbeats": true });
     let inverter: config::Inverter = serde_json::from_value(input).unwrap();
-    assert_eq!(inverter.heartbeats, Some(true));
+    assert_eq!(inverter.heartbeats(), true);
 }
 
 #[test]
 fn database_defaults() {
     let input = json!({ "url": "url" });
     let database: config::Database = serde_json::from_value(input).unwrap();
-    assert!(database.enabled);
+    assert!(database.enabled());
 }
 
 #[test]
 fn mqtt_defaults() {
     let input = json!({ "host": "host" });
     let mqtt: config::Mqtt = serde_json::from_value(input).unwrap();
-    assert!(mqtt.enabled);
-    assert_eq!(mqtt.port, 1883);
-    assert_eq!(mqtt.namespace, "lxp");
+    assert!(mqtt.enabled());
+    assert_eq!(mqtt.port(), 1883);
+    assert_eq!(mqtt.namespace(), "lxp");
 }
 
 #[test]
 fn homeassistant_defaults() {
     let input = json!({});
     let ha: config::HomeAssistant = serde_json::from_value(input).unwrap();
-    assert!(ha.enabled);
-    assert_eq!(ha.prefix, "homeassistant");
-    assert_eq!(ha.sensors, ["all"]);
+    assert!(ha.enabled());
+    assert_eq!(ha.prefix(), "homeassistant");
+    assert_eq!(ha.sensors(), &["all"]);
 }
 
 #[test]
 fn homeassistant_sensors_parsing() {
     let input = json!({ "sensors": "foo,bar" });
     let ha: config::HomeAssistant = serde_json::from_value(input).unwrap();
-    assert_eq!(ha.sensors, ["foo", "bar"]);
+    assert_eq!(ha.sensors(), &["foo", "bar"]);
 }
 
 #[test]

--- a/tests/test_coordinator.rs
+++ b/tests/test_coordinator.rs
@@ -23,9 +23,9 @@ async fn publishes_read_hold_mqtt() {
 
         // simulate ReadHold in from inverter
         let packet = Packet::TranslatedData(lxp::packet::TranslatedData {
-            datalog: *inverter.datalog(),
+            datalog: inverter.datalog(),
             device_function: lxp::packet::DeviceFunction::ReadHold,
-            inverter: *inverter.serial(),
+            inverter: inverter.serial(),
             register: 12,
             values: vec![22, 6],
         });
@@ -73,9 +73,9 @@ async fn handles_read_input_all() {
 
         // simulate ReadHold in from inverter
         let packet = Packet::TranslatedData(lxp::packet::TranslatedData {
-            datalog: *inverter.datalog(),
+            datalog: inverter.datalog(),
             device_function: lxp::packet::DeviceFunction::ReadInput,
-            inverter: *inverter.serial(),
+            inverter: inverter.serial(),
             register: 0,
             values: vec![1; 254],
         });
@@ -137,9 +137,9 @@ async fn complete_path_read_hold_command() {
 
         //   wait for inverter to receive the right packet
         let packet = Packet::TranslatedData(lxp::packet::TranslatedData {
-            datalog: *inverter.datalog(),
+            datalog: inverter.datalog(),
             device_function: lxp::packet::DeviceFunction::ReadHold,
-            inverter: *inverter.serial(),
+            inverter: inverter.serial(),
             register: 12,
             values: vec![1, 0],
         });
@@ -150,9 +150,9 @@ async fn complete_path_read_hold_command() {
 
         //   send the packet back from the inverter
         let reply = Packet::TranslatedData(lxp::packet::TranslatedData {
-            datalog: *inverter.datalog(),
+            datalog: inverter.datalog(),
             device_function: lxp::packet::DeviceFunction::ReadHold,
-            inverter: *inverter.serial(),
+            inverter: inverter.serial(),
             register: 12,
             values: vec![22, 6],
         });

--- a/tests/test_coordinator.rs
+++ b/tests/test_coordinator.rs
@@ -6,16 +6,15 @@ async fn publishes_read_hold_mqtt() {
     common_setup();
 
     // setup config with only mqtt enabled
-    let mut config = Factory::example_config();
-    config.influx.enabled = false;
-    config.databases[0].enabled = false;
-    let config = Rc::new(config);
+    let config = Factory::example_config_wrapped();
+    config.influx_mut().enabled = false;
+    config.databases_mut()[0].enabled = false;
 
-    let inverter = &config.inverters[0];
+    let inverter = &config.inverters()[0].clone();
 
     let channels = Channels::new();
 
-    let coordinator = Coordinator::new(Rc::clone(&config), channels.clone());
+    let coordinator = Coordinator::new(config, channels.clone());
 
     let tf = async {
         let mut to_influx = channels.to_influx.subscribe();
@@ -58,15 +57,14 @@ async fn publishes_read_hold_mqtt() {
 async fn handles_read_input_all() {
     common_setup();
 
-    let mut config = Factory::example_config();
-    config.influx.enabled = true;
-    config.databases[0].enabled = true;
-    let config = Rc::new(config);
-    let inverter = &config.inverters[0];
+    let config = Factory::example_config_wrapped();
+    config.influx_mut().enabled = true;
+    config.databases_mut()[0].enabled = true;
+    let inverter = config.inverters()[0].clone();
 
     let channels = Channels::new();
 
-    let coordinator = Coordinator::new(Rc::clone(&config), channels.clone());
+    let coordinator = Coordinator::new(config, channels.clone());
 
     let tf = async {
         let mut to_influx = channels.to_influx.subscribe();
@@ -114,13 +112,13 @@ async fn handles_read_input_all() {
 async fn complete_path_read_hold_command() {
     common_setup();
 
-    let config = Rc::new(Factory::example_config());
+    let config = Factory::example_config_wrapped();
 
-    let inverter = &config.inverters[0];
+    let inverter = config.inverters()[0].clone();
 
     let channels = Channels::new();
 
-    let coordinator = Coordinator::new(Rc::clone(&config), channels.clone());
+    let coordinator = Coordinator::new(config, channels.clone());
 
     let tf = async {
         let mut to_inverter = channels.to_inverter.subscribe();

--- a/tests/test_coordinator.rs
+++ b/tests/test_coordinator.rs
@@ -23,9 +23,9 @@ async fn publishes_read_hold_mqtt() {
 
         // simulate ReadHold in from inverter
         let packet = Packet::TranslatedData(lxp::packet::TranslatedData {
-            datalog: inverter.datalog,
+            datalog: *inverter.datalog(),
             device_function: lxp::packet::DeviceFunction::ReadHold,
-            inverter: inverter.serial,
+            inverter: *inverter.serial(),
             register: 12,
             values: vec![22, 6],
         });
@@ -37,7 +37,7 @@ async fn publishes_read_hold_mqtt() {
         assert_eq!(
             to_mqtt.recv().await?,
             mqtt::ChannelData::Message(mqtt::Message {
-                topic: format!("{}/hold/12", inverter.datalog),
+                topic: format!("{}/hold/12", inverter.datalog()),
                 payload: "1558".to_owned()
             })
         );
@@ -73,9 +73,9 @@ async fn handles_read_input_all() {
 
         // simulate ReadHold in from inverter
         let packet = Packet::TranslatedData(lxp::packet::TranslatedData {
-            datalog: inverter.datalog,
+            datalog: *inverter.datalog(),
             device_function: lxp::packet::DeviceFunction::ReadInput,
-            inverter: inverter.serial,
+            inverter: *inverter.serial(),
             register: 0,
             values: vec![1; 254],
         });
@@ -87,7 +87,7 @@ async fn handles_read_input_all() {
         assert_eq!(
             to_mqtt.recv().await?,
             mqtt::ChannelData::Message(mqtt::Message {
-                topic: format!("{}/inputs/all", inverter.datalog),
+                topic: format!("{}/inputs/all", inverter.datalog()),
                 payload: "{\"status\":257,\"v_pv\":77.1,\"v_pv_1\":25.7,\"v_pv_2\":25.7,\"v_pv_3\":25.7,\"v_bat\":25.7,\"soc\":1,\"soh\":1,\"p_pv\":771,\"p_pv_1\":257,\"p_pv_2\":257,\"p_pv_3\":257,\"p_charge\":257,\"p_discharge\":257,\"v_ac_r\":25.7,\"v_ac_s\":25.7,\"v_ac_t\":25.7,\"f_ac\":2.57,\"p_inv\":257,\"p_rec\":257,\"pf\":0.257,\"v_eps_r\":25.7,\"v_eps_s\":25.7,\"v_eps_t\":25.7,\"f_eps\":2.57,\"p_eps\":257,\"s_eps\":257,\"p_to_grid\":257,\"p_to_user\":257,\"e_pv_day\":77.1,\"e_pv_day_1\":25.7,\"e_pv_day_2\":25.7,\"e_pv_day_3\":25.7,\"e_inv_day\":25.7,\"e_rec_day\":25.7,\"e_chg_day\":25.7,\"e_dischg_day\":25.7,\"e_eps_day\":25.7,\"e_to_grid_day\":25.7,\"e_to_user_day\":25.7,\"v_bus_1\":25.7,\"v_bus_2\":25.7,\"e_pv_all\":5052902.699999999,\"e_pv_all_1\":1684300.9,\"e_pv_all_2\":1684300.9,\"e_pv_all_3\":1684300.9,\"e_inv_all\":1684300.9,\"e_rec_all\":1684300.9,\"e_chg_all\":1684300.9,\"e_dischg_all\":1684300.9,\"e_eps_all\":1684300.9,\"e_to_grid_all\":1684300.9,\"e_to_user_all\":1684300.9,\"t_inner\":257,\"t_rad_1\":257,\"t_rad_2\":257,\"t_bat\":257,\"runtime\":16843009,\"max_chg_curr\":2.57,\"max_dischg_curr\":2.57,\"charge_volt_ref\":25.7,\"dischg_cut_volt\":25.7,\"bat_status_0\":257,\"bat_status_1\":257,\"bat_status_2\":257,\"bat_status_3\":257,\"bat_status_4\":257,\"bat_status_5\":257,\"bat_status_6\":257,\"bat_status_7\":257,\"bat_status_8\":257,\"bat_status_9\":257,\"bat_status_inv\":257,\"bat_count\":257,\"bat_capacity\":257,\"bat_current\":2.57,\"bms_event_1\":257,\"bms_event_2\":257,\"max_cell_voltage\":2.57,\"min_cell_voltage\":2.57,\"max_cell_temp\":2.57,\"min_cell_temp\":2.57,\"bms_fw_update_state\":257,\"cycle_count\":257,\"vbat_inv\":25.7,\"time\":1646370367,\"datalog\":\"2222222222\"}".to_owned()
             })
         );
@@ -137,9 +137,9 @@ async fn complete_path_read_hold_command() {
 
         //   wait for inverter to receive the right packet
         let packet = Packet::TranslatedData(lxp::packet::TranslatedData {
-            datalog: inverter.datalog,
+            datalog: *inverter.datalog(),
             device_function: lxp::packet::DeviceFunction::ReadHold,
-            inverter: inverter.serial,
+            inverter: *inverter.serial(),
             register: 12,
             values: vec![1, 0],
         });
@@ -150,9 +150,9 @@ async fn complete_path_read_hold_command() {
 
         //   send the packet back from the inverter
         let reply = Packet::TranslatedData(lxp::packet::TranslatedData {
-            datalog: inverter.datalog,
+            datalog: *inverter.datalog(),
             device_function: lxp::packet::DeviceFunction::ReadHold,
-            inverter: inverter.serial,
+            inverter: *inverter.serial(),
             register: 12,
             values: vec![22, 6],
         });

--- a/tests/test_coordinator_commands_read_hold.rs
+++ b/tests/test_coordinator_commands_read_hold.rs
@@ -19,9 +19,9 @@ async fn happy_path() {
     );
 
     let reply = Packet::TranslatedData(lxp::packet::TranslatedData {
-        datalog: *inverter.datalog(),
+        datalog: inverter.datalog(),
         device_function: lxp::packet::DeviceFunction::ReadHold,
-        inverter: *inverter.serial(),
+        inverter: inverter.serial(),
         register: 0,
         values: vec![0, 0],
     });

--- a/tests/test_coordinator_commands_read_hold.rs
+++ b/tests/test_coordinator_commands_read_hold.rs
@@ -19,9 +19,9 @@ async fn happy_path() {
     );
 
     let reply = Packet::TranslatedData(lxp::packet::TranslatedData {
-        datalog: inverter.datalog,
+        datalog: *inverter.datalog(),
         device_function: lxp::packet::DeviceFunction::ReadHold,
-        inverter: inverter.serial,
+        inverter: *inverter.serial(),
         register: 0,
         values: vec![0, 0],
     });

--- a/tests/test_coordinator_commands_read_inputs.rs
+++ b/tests/test_coordinator_commands_read_inputs.rs
@@ -19,9 +19,9 @@ async fn happy_path() {
     );
 
     let reply = Packet::TranslatedData(lxp::packet::TranslatedData {
-        datalog: inverter.datalog,
+        datalog: *inverter.datalog(),
         device_function: lxp::packet::DeviceFunction::ReadInput,
-        inverter: inverter.serial,
+        inverter: *inverter.serial(),
         register: 0,
         values: vec![0, 0],
     });

--- a/tests/test_coordinator_commands_read_inputs.rs
+++ b/tests/test_coordinator_commands_read_inputs.rs
@@ -19,9 +19,9 @@ async fn happy_path() {
     );
 
     let reply = Packet::TranslatedData(lxp::packet::TranslatedData {
-        datalog: *inverter.datalog(),
+        datalog: inverter.datalog(),
         device_function: lxp::packet::DeviceFunction::ReadInput,
-        inverter: *inverter.serial(),
+        inverter: inverter.serial(),
         register: 0,
         values: vec![0, 0],
     });

--- a/tests/test_coordinator_commands_set_hold.rs
+++ b/tests/test_coordinator_commands_set_hold.rs
@@ -19,9 +19,9 @@ async fn happy_path() {
     );
 
     let reply = Packet::TranslatedData(lxp::packet::TranslatedData {
-        datalog: *inverter.datalog(),
+        datalog: inverter.datalog(),
         device_function: lxp::packet::DeviceFunction::WriteSingle,
-        inverter: *inverter.serial(),
+        inverter: inverter.serial(),
         register: 5,
         values: vec![10, 0],
     });
@@ -61,9 +61,9 @@ async fn bad_reply() {
     );
 
     let reply = Packet::TranslatedData(lxp::packet::TranslatedData {
-        datalog: *inverter.datalog(),
+        datalog: inverter.datalog(),
         device_function: lxp::packet::DeviceFunction::WriteSingle,
-        inverter: *inverter.serial(),
+        inverter: inverter.serial(),
         register: 5,
         values: vec![200, 0], // reply has wrong value
     });

--- a/tests/test_coordinator_commands_set_hold.rs
+++ b/tests/test_coordinator_commands_set_hold.rs
@@ -19,9 +19,9 @@ async fn happy_path() {
     );
 
     let reply = Packet::TranslatedData(lxp::packet::TranslatedData {
-        datalog: inverter.datalog,
+        datalog: *inverter.datalog(),
         device_function: lxp::packet::DeviceFunction::WriteSingle,
-        inverter: inverter.serial,
+        inverter: *inverter.serial(),
         register: 5,
         values: vec![10, 0],
     });
@@ -61,9 +61,9 @@ async fn bad_reply() {
     );
 
     let reply = Packet::TranslatedData(lxp::packet::TranslatedData {
-        datalog: inverter.datalog,
+        datalog: *inverter.datalog(),
         device_function: lxp::packet::DeviceFunction::WriteSingle,
-        inverter: inverter.serial,
+        inverter: *inverter.serial(),
         register: 5,
         values: vec![200, 0], // reply has wrong value
     });

--- a/tests/test_coordinator_commands_time_sync.rs
+++ b/tests/test_coordinator_commands_time_sync.rs
@@ -21,9 +21,9 @@ async fn update_time() {
         assert_eq!(
             unwrap_inverter_channeldata_packet(channels.to_inverter.subscribe().recv().await?),
             Packet::TranslatedData(lxp::packet::TranslatedData {
-                datalog: *inverter.datalog(),
+                datalog: inverter.datalog(),
                 device_function: lxp::packet::DeviceFunction::ReadHold,
-                inverter: *inverter.serial(),
+                inverter: inverter.serial(),
                 register: 12,
                 values: vec![3, 0]
             })
@@ -31,9 +31,9 @@ async fn update_time() {
 
         // send reply with time of 2022-06-18 21:03:10
         let inverter_time_packet = Packet::TranslatedData(lxp::packet::TranslatedData {
-            datalog: *inverter.datalog(),
+            datalog: inverter.datalog(),
             device_function: lxp::packet::DeviceFunction::ReadHold,
-            inverter: *inverter.serial(),
+            inverter: inverter.serial(),
             register: 12,
             values: vec![22, 6, 18, 21, 03, 10],
         });
@@ -45,9 +45,9 @@ async fn update_time() {
         assert_eq!(
             unwrap_inverter_channeldata_packet(channels.to_inverter.subscribe().recv().await?),
             Packet::TranslatedData(lxp::packet::TranslatedData {
-                datalog: *inverter.datalog(),
+                datalog: inverter.datalog(),
                 device_function: lxp::packet::DeviceFunction::WriteMulti,
-                inverter: *inverter.serial(),
+                inverter: inverter.serial(),
                 register: 12,
                 values: vec![22, 3, 4, 5, 6, 7] // hardcoded test time
             })
@@ -55,9 +55,9 @@ async fn update_time() {
 
         // send reply that we set the time
         let inverter_ok_packet = Packet::TranslatedData(lxp::packet::TranslatedData {
-            datalog: *inverter.datalog(),
+            datalog: inverter.datalog(),
             device_function: lxp::packet::DeviceFunction::WriteMulti,
-            inverter: *inverter.serial(),
+            inverter: inverter.serial(),
             register: 12,
             values: vec![3, 0],
         });
@@ -91,9 +91,9 @@ async fn time_already_correct() {
         assert_eq!(
             unwrap_inverter_channeldata_packet(channels.to_inverter.subscribe().recv().await?),
             Packet::TranslatedData(lxp::packet::TranslatedData {
-                datalog: *inverter.datalog(),
+                datalog: inverter.datalog(),
                 device_function: lxp::packet::DeviceFunction::ReadHold,
-                inverter: *inverter.serial(),
+                inverter: inverter.serial(),
                 register: 12,
                 values: vec![3, 0]
             })
@@ -101,9 +101,9 @@ async fn time_already_correct() {
 
         // send reply with hardcoded test time
         let inverter_time_packet = Packet::TranslatedData(lxp::packet::TranslatedData {
-            datalog: *inverter.datalog(),
+            datalog: inverter.datalog(),
             device_function: lxp::packet::DeviceFunction::ReadHold,
-            inverter: *inverter.serial(),
+            inverter: inverter.serial(),
             register: 12,
             values: vec![22, 3, 4, 5, 6, 7], // hardcoded test time
         });

--- a/tests/test_coordinator_commands_time_sync.rs
+++ b/tests/test_coordinator_commands_time_sync.rs
@@ -21,9 +21,9 @@ async fn update_time() {
         assert_eq!(
             unwrap_inverter_channeldata_packet(channels.to_inverter.subscribe().recv().await?),
             Packet::TranslatedData(lxp::packet::TranslatedData {
-                datalog: inverter.datalog,
+                datalog: *inverter.datalog(),
                 device_function: lxp::packet::DeviceFunction::ReadHold,
-                inverter: inverter.serial,
+                inverter: *inverter.serial(),
                 register: 12,
                 values: vec![3, 0]
             })
@@ -31,9 +31,9 @@ async fn update_time() {
 
         // send reply with time of 2022-06-18 21:03:10
         let inverter_time_packet = Packet::TranslatedData(lxp::packet::TranslatedData {
-            datalog: inverter.datalog,
+            datalog: *inverter.datalog(),
             device_function: lxp::packet::DeviceFunction::ReadHold,
-            inverter: inverter.serial,
+            inverter: *inverter.serial(),
             register: 12,
             values: vec![22, 6, 18, 21, 03, 10],
         });
@@ -45,9 +45,9 @@ async fn update_time() {
         assert_eq!(
             unwrap_inverter_channeldata_packet(channels.to_inverter.subscribe().recv().await?),
             Packet::TranslatedData(lxp::packet::TranslatedData {
-                datalog: inverter.datalog,
+                datalog: *inverter.datalog(),
                 device_function: lxp::packet::DeviceFunction::WriteMulti,
-                inverter: inverter.serial,
+                inverter: *inverter.serial(),
                 register: 12,
                 values: vec![22, 3, 4, 5, 6, 7] // hardcoded test time
             })
@@ -55,9 +55,9 @@ async fn update_time() {
 
         // send reply that we set the time
         let inverter_ok_packet = Packet::TranslatedData(lxp::packet::TranslatedData {
-            datalog: inverter.datalog,
+            datalog: *inverter.datalog(),
             device_function: lxp::packet::DeviceFunction::WriteMulti,
-            inverter: inverter.serial,
+            inverter: *inverter.serial(),
             register: 12,
             values: vec![3, 0],
         });
@@ -91,9 +91,9 @@ async fn time_already_correct() {
         assert_eq!(
             unwrap_inverter_channeldata_packet(channels.to_inverter.subscribe().recv().await?),
             Packet::TranslatedData(lxp::packet::TranslatedData {
-                datalog: inverter.datalog,
+                datalog: *inverter.datalog(),
                 device_function: lxp::packet::DeviceFunction::ReadHold,
-                inverter: inverter.serial,
+                inverter: *inverter.serial(),
                 register: 12,
                 values: vec![3, 0]
             })
@@ -101,9 +101,9 @@ async fn time_already_correct() {
 
         // send reply with hardcoded test time
         let inverter_time_packet = Packet::TranslatedData(lxp::packet::TranslatedData {
-            datalog: inverter.datalog,
+            datalog: *inverter.datalog(),
             device_function: lxp::packet::DeviceFunction::ReadHold,
-            inverter: inverter.serial,
+            inverter: *inverter.serial(),
             register: 12,
             values: vec![22, 3, 4, 5, 6, 7], // hardcoded test time
         });

--- a/tests/test_coordinator_commands_update_hold.rs
+++ b/tests/test_coordinator_commands_update_hold.rs
@@ -25,9 +25,9 @@ async fn happy_path() {
         assert_eq!(
             result?,
             Packet::TranslatedData(lxp::packet::TranslatedData {
-                datalog: *inverter.datalog(),
+                datalog: inverter.datalog(),
                 device_function: lxp::packet::DeviceFunction::WriteSingle,
-                inverter: *inverter.serial(),
+                inverter: inverter.serial(),
                 register: 21,
                 values: vec![130, 0],
             })
@@ -43,9 +43,9 @@ async fn happy_path() {
         assert_eq!(
             unwrap_inverter_channeldata_packet(to_inverter.recv().await?),
             Packet::TranslatedData(lxp::packet::TranslatedData {
-                datalog: *inverter.datalog(),
+                datalog: inverter.datalog(),
                 device_function: lxp::packet::DeviceFunction::ReadHold,
-                inverter: *inverter.serial(),
+                inverter: inverter.serial(),
                 register: 21,
                 values: vec![1, 0]
             })
@@ -53,9 +53,9 @@ async fn happy_path() {
 
         // send reply with current values
         let reply = Packet::TranslatedData(lxp::packet::TranslatedData {
-            datalog: *inverter.datalog(),
+            datalog: inverter.datalog(),
             device_function: lxp::packet::DeviceFunction::ReadHold,
-            inverter: *inverter.serial(),
+            inverter: inverter.serial(),
             register: 21,
             values: vec![2, 0],
         });
@@ -67,9 +67,9 @@ async fn happy_path() {
         assert_eq!(
             unwrap_inverter_channeldata_packet(to_inverter.recv().await?),
             Packet::TranslatedData(lxp::packet::TranslatedData {
-                datalog: *inverter.datalog(),
+                datalog: inverter.datalog(),
                 device_function: lxp::packet::DeviceFunction::WriteSingle,
-                inverter: *inverter.serial(),
+                inverter: inverter.serial(),
                 register: 21,
                 values: vec![130, 0] // 128 + 2
             })
@@ -77,9 +77,9 @@ async fn happy_path() {
 
         // send reply with new value
         let reply = Packet::TranslatedData(lxp::packet::TranslatedData {
-            datalog: *inverter.datalog(),
+            datalog: inverter.datalog(),
             device_function: lxp::packet::DeviceFunction::WriteSingle,
-            inverter: *inverter.serial(),
+            inverter: inverter.serial(),
             register: 21,
             values: vec![130, 0],
         });
@@ -126,9 +126,9 @@ async fn no_reply() {
         assert_eq!(
             unwrap_inverter_channeldata_packet(channels.to_inverter.subscribe().recv().await?),
             Packet::TranslatedData(lxp::packet::TranslatedData {
-                datalog: *inverter.datalog(),
+                datalog: inverter.datalog(),
                 device_function: lxp::packet::DeviceFunction::ReadHold,
-                inverter: *inverter.serial(),
+                inverter: inverter.serial(),
                 register: 21,
                 values: vec![1, 0]
             })

--- a/tests/test_coordinator_commands_update_hold.rs
+++ b/tests/test_coordinator_commands_update_hold.rs
@@ -25,9 +25,9 @@ async fn happy_path() {
         assert_eq!(
             result?,
             Packet::TranslatedData(lxp::packet::TranslatedData {
-                datalog: inverter.datalog,
+                datalog: *inverter.datalog(),
                 device_function: lxp::packet::DeviceFunction::WriteSingle,
-                inverter: inverter.serial,
+                inverter: *inverter.serial(),
                 register: 21,
                 values: vec![130, 0],
             })
@@ -43,9 +43,9 @@ async fn happy_path() {
         assert_eq!(
             unwrap_inverter_channeldata_packet(to_inverter.recv().await?),
             Packet::TranslatedData(lxp::packet::TranslatedData {
-                datalog: inverter.datalog,
+                datalog: *inverter.datalog(),
                 device_function: lxp::packet::DeviceFunction::ReadHold,
-                inverter: inverter.serial,
+                inverter: *inverter.serial(),
                 register: 21,
                 values: vec![1, 0]
             })
@@ -53,9 +53,9 @@ async fn happy_path() {
 
         // send reply with current values
         let reply = Packet::TranslatedData(lxp::packet::TranslatedData {
-            datalog: inverter.datalog,
+            datalog: *inverter.datalog(),
             device_function: lxp::packet::DeviceFunction::ReadHold,
-            inverter: inverter.serial,
+            inverter: *inverter.serial(),
             register: 21,
             values: vec![2, 0],
         });
@@ -67,9 +67,9 @@ async fn happy_path() {
         assert_eq!(
             unwrap_inverter_channeldata_packet(to_inverter.recv().await?),
             Packet::TranslatedData(lxp::packet::TranslatedData {
-                datalog: inverter.datalog,
+                datalog: *inverter.datalog(),
                 device_function: lxp::packet::DeviceFunction::WriteSingle,
-                inverter: inverter.serial,
+                inverter: *inverter.serial(),
                 register: 21,
                 values: vec![130, 0] // 128 + 2
             })
@@ -77,9 +77,9 @@ async fn happy_path() {
 
         // send reply with new value
         let reply = Packet::TranslatedData(lxp::packet::TranslatedData {
-            datalog: inverter.datalog,
+            datalog: *inverter.datalog(),
             device_function: lxp::packet::DeviceFunction::WriteSingle,
-            inverter: inverter.serial,
+            inverter: *inverter.serial(),
             register: 21,
             values: vec![130, 0],
         });
@@ -126,9 +126,9 @@ async fn no_reply() {
         assert_eq!(
             unwrap_inverter_channeldata_packet(channels.to_inverter.subscribe().recv().await?),
             Packet::TranslatedData(lxp::packet::TranslatedData {
-                datalog: inverter.datalog,
+                datalog: *inverter.datalog(),
                 device_function: lxp::packet::DeviceFunction::ReadHold,
-                inverter: inverter.serial,
+                inverter: *inverter.serial(),
                 register: 21,
                 values: vec![1, 0]
             })

--- a/tests/test_influx.rs
+++ b/tests/test_influx.rs
@@ -11,11 +11,12 @@ fn mock_influxdb() -> Mock {
 async fn sends_http_request() {
     common_setup();
 
-    let mut config = Factory::example_config();
-    config.influx.url = mockito::server_url();
+    let config = Factory::example_config_wrapped();
+    //config.set_influx_url(mockito::server_url());
+    config.influx_mut().url = mockito::server_url();
     let channels = Channels::new();
 
-    let influx = Influx::new(Rc::new(config), channels.clone());
+    let influx = Influx::new(config, channels.clone());
 
     let tf = async {
         let json = json!({ "time": 1, "soc": 100, "v_bat": 52.4 });

--- a/tests/test_inverter.rs
+++ b/tests/test_inverter.rs
@@ -12,7 +12,8 @@ async fn serials_fixed_in_outgoing_packets() {
 
     common_setup();
 
-    let config = config::Inverter {
+    let config = Factory::example_config_wrapped();
+    let inverter = config::Inverter {
         enabled: true,
         host: "localhost".to_owned(),
         port: 1235,
@@ -21,7 +22,7 @@ async fn serials_fixed_in_outgoing_packets() {
         heartbeats: None,
     };
     let channels = Channels::new();
-    let inverter = lxp::inverter::Inverter::new(config, channels.clone());
+    let inverter = lxp::inverter::Inverter::new(config, &inverter, channels.clone());
 
     let mut from_inverter = channels.from_inverter.subscribe();
 
@@ -99,7 +100,8 @@ async fn serials_fixed_in_outgoing_packets() {
 async fn test_replies_to_heartbeats() {
     common_setup();
 
-    let config = config::Inverter {
+    let config = Factory::example_config_wrapped();
+    let inverter = config::Inverter {
         enabled: true,
         host: "localhost".to_owned(),
         port: 1235,
@@ -108,7 +110,7 @@ async fn test_replies_to_heartbeats() {
         heartbeats: Some(true),
     };
     let channels = Channels::new();
-    let inverter = lxp::inverter::Inverter::new(config, channels.clone());
+    let inverter = lxp::inverter::Inverter::new(config, &inverter, channels.clone());
 
     let from_inverter = channels.from_inverter.subscribe();
 

--- a/tests/test_mqtt_message.rs
+++ b/tests/test_mqtt_message.rs
@@ -8,7 +8,7 @@ async fn for_param() {
     let inverter = Factory::inverter();
 
     let packet = lxp::packet::ReadParam {
-        datalog: *inverter.datalog(),
+        datalog: inverter.datalog(),
         register: 0,
         values: vec![1, 0],
     };
@@ -29,9 +29,9 @@ async fn for_hold_single() {
     let inverter = Factory::inverter();
 
     let packet = lxp::packet::TranslatedData {
-        datalog: *inverter.datalog(),
+        datalog: inverter.datalog(),
         device_function: lxp::packet::DeviceFunction::ReadHold,
-        inverter: *inverter.serial(),
+        inverter: inverter.serial(),
         register: 0,
         values: vec![1, 0],
     };
@@ -108,9 +108,9 @@ async fn for_input_ignore_127_254() {
     let inverter = Factory::inverter();
 
     let packet = lxp::packet::TranslatedData {
-        datalog: *inverter.datalog(),
+        datalog: inverter.datalog(),
         device_function: lxp::packet::DeviceFunction::ReadInput,
-        inverter: *inverter.serial(),
+        inverter: inverter.serial(),
         register: 127,
         values: [0; 254].to_vec(),
     };

--- a/tests/test_mqtt_message.rs
+++ b/tests/test_mqtt_message.rs
@@ -8,7 +8,7 @@ async fn for_param() {
     let inverter = Factory::inverter();
 
     let packet = lxp::packet::ReadParam {
-        datalog: inverter.datalog,
+        datalog: *inverter.datalog(),
         register: 0,
         values: vec![1, 0],
     };
@@ -29,9 +29,9 @@ async fn for_hold_single() {
     let inverter = Factory::inverter();
 
     let packet = lxp::packet::TranslatedData {
-        datalog: inverter.datalog,
+        datalog: *inverter.datalog(),
         device_function: lxp::packet::DeviceFunction::ReadHold,
-        inverter: inverter.serial,
+        inverter: *inverter.serial(),
         register: 0,
         values: vec![1, 0],
     };
@@ -108,9 +108,9 @@ async fn for_input_ignore_127_254() {
     let inverter = Factory::inverter();
 
     let packet = lxp::packet::TranslatedData {
-        datalog: inverter.datalog,
+        datalog: *inverter.datalog(),
         device_function: lxp::packet::DeviceFunction::ReadInput,
-        inverter: inverter.serial,
+        inverter: *inverter.serial(),
         register: 127,
         values: [0; 254].to_vec(),
     };


### PR DESCRIPTION
Should pave the way for more centralised configuration management, including changing bits of configuration while running.

I'd like to get rid of all the `pub` accessors in configuration, but that made tests a lot harder to write and it got messy so they can stay for now. All of the real code usage is using the new getters which should be the way forward so I can encapsulate logic in there, such as for `enabled` which is already done.