### PR TITLE
Experiment: add cmd/read/input/X and publishing of raw input registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.10.0 - Unreleased
 
 * Fix crash in scheduler during DST transition times (#107)
+* Add read individual input command and optional publishing of individual input registers (#111)
 
 
 # 0.9.0 - 2nd November 2022

--- a/src/command.rs
+++ b/src/command.rs
@@ -5,6 +5,7 @@ pub enum Command {
     ReadInputs1(config::Inverter),
     ReadInputs2(config::Inverter),
     ReadInputs3(config::Inverter),
+    ReadInput(config::Inverter, u16, u16),
     ReadHold(config::Inverter, u16, u16),
     ReadParam(config::Inverter, u16),
     SetHold(config::Inverter, u16, u16),
@@ -22,6 +23,9 @@ impl Command {
         use Command::*;
 
         let rest = match self {
+            ReadInput(inverter, register, _) => {
+                format!("{}/read/input/{}", inverter.datalog(), register)
+            }
             ReadInputs1(inverter) => format!("{}/read/inputs/1", inverter.datalog()),
             ReadInputs2(inverter) => format!("{}/read/inputs/2", inverter.datalog()),
             ReadInputs3(inverter) => format!("{}/read/inputs/3", inverter.datalog()),

--- a/src/command.rs
+++ b/src/command.rs
@@ -2,9 +2,7 @@ use crate::prelude::*;
 
 #[derive(Debug)]
 pub enum Command {
-    ReadInputs1(config::Inverter),
-    ReadInputs2(config::Inverter),
-    ReadInputs3(config::Inverter),
+    ReadInputs(config::Inverter, u16),
     ReadInput(config::Inverter, u16, u16),
     ReadHold(config::Inverter, u16, u16),
     ReadParam(config::Inverter, u16),
@@ -23,12 +21,10 @@ impl Command {
         use Command::*;
 
         let rest = match self {
+            ReadInputs(inverter, c) => format!("{}/read/inputs/{}", inverter.datalog(), c),
             ReadInput(inverter, register, _) => {
                 format!("{}/read/input/{}", inverter.datalog(), register)
             }
-            ReadInputs1(inverter) => format!("{}/read/inputs/1", inverter.datalog()),
-            ReadInputs2(inverter) => format!("{}/read/inputs/2", inverter.datalog()),
-            ReadInputs3(inverter) => format!("{}/read/inputs/3", inverter.datalog()),
             ReadHold(inverter, register, _) => {
                 format!("{}/read/hold/{}", inverter.datalog(), register)
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -273,11 +273,12 @@ impl ConfigWrapper {
     }
 
     pub fn inverters_for_message(&self, message: &mqtt::Message) -> Result<Vec<Inverter>> {
-        use mqtt::SerialOrAll::*;
+        use mqtt::TargetInverter::*;
 
+        let (target_inverter, _) = message.split_cmd_topic()?;
         let inverters = self.enabled_inverters();
 
-        let r = match message.split_cmd_topic()? {
+        let r = match target_inverter {
             All => inverters,
             Serial(datalog) => inverters
                 .iter()

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,6 +103,8 @@ pub struct Mqtt {
 
     #[serde(default = "Config::default_mqtt_homeassistant")]
     pub homeassistant: HomeAssistant,
+
+    pub publish_individual_input: Option<bool>,
 }
 impl Mqtt {
     pub fn enabled(&self) -> bool {
@@ -131,6 +133,10 @@ impl Mqtt {
 
     pub fn homeassistant(&self) -> &HomeAssistant {
         &self.homeassistant
+    }
+
+    pub fn publish_individual_input(&self) -> bool {
+        self.publish_individual_input == Some(true)
     }
 } // }}}
 

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -82,9 +82,10 @@ impl Coordinator {
         use Command::*;
 
         match command {
-            ReadInputs1(inverter) => self.read_inputs(inverter, 0_u16, 40).await,
-            ReadInputs2(inverter) => self.read_inputs(inverter, 40_u16, 40).await,
-            ReadInputs3(inverter) => self.read_inputs(inverter, 80_u16, 40).await,
+            ReadInputs(inverter, 1) => self.read_inputs(inverter, 0_u16, 40).await,
+            ReadInputs(inverter, 2) => self.read_inputs(inverter, 40_u16, 40).await,
+            ReadInputs(inverter, 3) => self.read_inputs(inverter, 80_u16, 40).await,
+            ReadInputs(_, _) => bail!("cmd/read/inputs/n must be 1-3"),
             ReadInput(inverter, register, count) => {
                 self.read_inputs(inverter, register, count).await
             }

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -85,6 +85,9 @@ impl Coordinator {
             ReadInputs1(inverter) => self.read_inputs(inverter, 0_u16, 40).await,
             ReadInputs2(inverter) => self.read_inputs(inverter, 40_u16, 40).await,
             ReadInputs3(inverter) => self.read_inputs(inverter, 80_u16, 40).await,
+            ReadInput(inverter, register, count) => {
+                self.read_inputs(inverter, register, count).await
+            }
             ReadHold(inverter, register, count) => self.read_hold(inverter, register, count).await,
             ReadParam(inverter, register) => self.read_param(inverter, register).await,
             SetHold(inverter, register, value) => self.set_hold(inverter, register, value).await,
@@ -296,7 +299,7 @@ impl Coordinator {
             // returns a Vec of messages to send. could be none;
             // not every packet produces an MQ message (eg, heartbeats),
             // and some produce >1 (multi-register ReadHold)
-            match Self::packet_to_messages(packet) {
+            match Self::packet_to_messages(packet, self.config.mqtt().publish_individual_input()) {
                 Ok(messages) => {
                     for message in messages {
                         let message = mqtt::ChannelData::Message(message);
@@ -334,12 +337,15 @@ impl Coordinator {
         Ok(())
     }
 
-    fn packet_to_messages(packet: Packet) -> Result<Vec<mqtt::Message>> {
+    fn packet_to_messages(
+        packet: Packet,
+        publish_individual_input: bool,
+    ) -> Result<Vec<mqtt::Message>> {
         match packet {
             Packet::Heartbeat(_) => Ok(Vec::new()), // always no message
             Packet::TranslatedData(td) => match td.device_function {
                 DeviceFunction::ReadHold => mqtt::Message::for_hold(td),
-                DeviceFunction::ReadInput => mqtt::Message::for_input(td),
+                DeviceFunction::ReadInput => mqtt::Message::for_input(td, publish_individual_input),
                 DeviceFunction::WriteSingle => mqtt::Message::for_hold(td),
                 DeviceFunction::WriteMulti => Ok(Vec::new()), // TODO, for_hold might just work
             },

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -85,7 +85,7 @@ impl Coordinator {
             ReadInputs(inverter, 1) => self.read_inputs(inverter, 0_u16, 40).await,
             ReadInputs(inverter, 2) => self.read_inputs(inverter, 40_u16, 40).await,
             ReadInputs(inverter, 3) => self.read_inputs(inverter, 80_u16, 40).await,
-            ReadInputs(_, _) => bail!("cmd/read/inputs/n must be 1-3"),
+            ReadInputs(_, _) => unreachable!(),
             ReadInput(inverter, register, count) => {
                 self.read_inputs(inverter, register, count).await
             }

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -97,9 +97,9 @@ impl Message {
         let (_datalog, parts) = self.split_cmd_topic()?;
 
         let r = match parts[..] {
-            ["read", "inputs", "1"] => ReadInputs1(inverter),
-            ["read", "inputs", "2"] => ReadInputs2(inverter),
-            ["read", "inputs", "3"] => ReadInputs3(inverter),
+            ["read", "inputs", "1"] => ReadInputs(inverter, 1),
+            ["read", "inputs", "2"] => ReadInputs(inverter, 2),
+            ["read", "inputs", "3"] => ReadInputs(inverter, 3),
             ["read", "input", register] => {
                 ReadInput(inverter, register.parse()?, self.payload_int_or_1()?)
             }

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -9,7 +9,7 @@ pub struct Message {
     pub payload: String,
 }
 
-pub enum SerialOrAll {
+pub enum TargetInverter {
     Serial(Serial),
     All,
 }
@@ -94,11 +94,9 @@ impl Message {
     pub fn to_command(&self, inverter: config::Inverter) -> Result<Command> {
         use Command::*;
 
-        let parts: Vec<&str> = self.topic.split('/').collect();
-        let _datalog = parts[1];
-        let parts = &parts[2..];
+        let (_datalog, parts) = self.split_cmd_topic()?;
 
-        let r = match parts {
+        let r = match parts[..] {
             ["read", "inputs", "1"] => ReadInputs1(inverter),
             ["read", "inputs", "2"] => ReadInputs2(inverter),
             ["read", "inputs", "3"] => ReadInputs3(inverter),
@@ -129,12 +127,12 @@ impl Message {
 
         Ok(r)
     }
+
     // given a cmd Message, return the datalog it is intended for.
     //
-    // eg cmd/AB12345678/ac_charge => AB12345678
-    pub fn split_cmd_topic(&self) -> Result<SerialOrAll> {
-        // this starts at cmd/{datalog}/..
-        let parts: Vec<String> = self.topic.split('/').map(|x| x.to_string()).collect();
+    // eg cmd/AB12345678/set/ac_charge => (AB12345678, ['set', 'ac_charge'])
+    pub fn split_cmd_topic(&self) -> Result<(TargetInverter, Vec<&str>)> {
+        let parts: Vec<&str> = self.topic.split('/').collect();
 
         // bail if the topic is too short to handle.
         // this *shouldn't* happen as our subscribe is for lxp/cmd/{datalog}/#
@@ -142,12 +140,16 @@ impl Message {
             bail!("ignoring badly formed MQTT topic: {}", self.topic);
         }
 
-        if parts[1] == "all" {
-            return Ok(SerialOrAll::All);
-        }
+        // parts[0] should be cmd
+        let datalog = parts[1];
+        let rest = parts[2..].to_vec();
 
-        let serial = Serial::from_str(&parts[1])?;
-        Ok(SerialOrAll::Serial(serial))
+        if datalog == "all" {
+            Ok((TargetInverter::All, rest))
+        } else {
+            let serial = Serial::from_str(&datalog)?;
+            Ok((TargetInverter::Serial(serial), rest))
+        }
     }
 
     pub fn payload_int_or_1(&self) -> Result<u16> {

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -204,7 +204,7 @@ impl Mqtt {
             return Ok(());
         }
 
-        let mut options = MqttOptions::new("lxp-bridge2", c.mqtt().host(), c.mqtt().port());
+        let mut options = MqttOptions::new("lxp-bridge", c.mqtt().host(), c.mqtt().port());
 
         options.set_keep_alive(std::time::Duration::from_secs(60));
         if let (Some(u), Some(p)) = (c.mqtt().username(), c.mqtt().password()) {

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -9,11 +9,6 @@ pub struct Message {
     pub payload: String,
 }
 
-pub struct MessageTopicParts {
-    pub datalog: Serial,
-    pub parts: Vec<String>,
-}
-
 pub enum SerialOrAll {
     Serial(Serial),
     All,

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -147,7 +147,7 @@ impl Message {
         if datalog == "all" {
             Ok((TargetInverter::All, rest))
         } else {
-            let serial = Serial::from_str(&datalog)?;
+            let serial = Serial::from_str(datalog)?;
             Ok((TargetInverter::Serial(serial), rest))
         }
     }

--- a/tests/test_mqtt_message.rs
+++ b/tests/test_mqtt_message.rs
@@ -93,11 +93,33 @@ async fn for_input() {
     };
 
     assert_eq!(
-        mqtt::Message::for_input(packet).unwrap(),
+        mqtt::Message::for_input(packet, false).unwrap(),
         vec![mqtt::Message {
             topic: "2222222222/inputs/1".to_owned(),
             payload: "{\"status\":0,\"v_pv\":0.0,\"v_pv_1\":0.0,\"v_pv_2\":0.0,\"v_pv_3\":0.0,\"v_bat\":0.0,\"soc\":0,\"soh\":0,\"p_pv\":0,\"p_pv_1\":0,\"p_pv_2\":0,\"p_pv_3\":0,\"p_charge\":0,\"p_discharge\":0,\"v_ac_r\":0.0,\"v_ac_s\":0.0,\"v_ac_t\":0.0,\"f_ac\":0.0,\"p_inv\":0,\"p_rec\":0,\"pf\":0.0,\"v_eps_r\":0.0,\"v_eps_s\":0.0,\"v_eps_t\":0.0,\"f_eps\":0.0,\"p_eps\":0,\"s_eps\":0,\"p_to_grid\":0,\"p_to_user\":0,\"e_pv_day\":0.0,\"e_pv_day_1\":0.0,\"e_pv_day_2\":0.0,\"e_pv_day_3\":0.0,\"e_inv_day\":0.0,\"e_rec_day\":0.0,\"e_chg_day\":0.0,\"e_dischg_day\":0.0,\"e_eps_day\":0.0,\"e_to_grid_day\":0.0,\"e_to_user_day\":0.0,\"v_bus_1\":0.0,\"v_bus_2\":0.0,\"time\":1646370367,\"datalog\":\"2222222222\"}".to_owned()
         }]
+    );
+
+    let packet = lxp::packet::TranslatedData {
+        datalog: inverter.datalog,
+        device_function: lxp::packet::DeviceFunction::ReadInput,
+        inverter: inverter.serial,
+        register: 0,
+        values: [0; 4].to_vec(),
+    };
+
+    assert_eq!(
+        mqtt::Message::for_input(packet, true).unwrap(),
+        vec![
+            mqtt::Message {
+                topic: "2222222222/input/0".to_owned(),
+                payload: "0".to_owned()
+            },
+            mqtt::Message {
+                topic: "2222222222/input/1".to_owned(),
+                payload: "0".to_owned()
+            }
+        ]
     );
 }
 
@@ -115,5 +137,5 @@ async fn for_input_ignore_127_254() {
         values: [0; 254].to_vec(),
     };
 
-    assert_eq!(mqtt::Message::for_input(packet).unwrap(), vec![]);
+    assert_eq!(mqtt::Message::for_input(packet, false).unwrap(), vec![]);
 }


### PR DESCRIPTION
There's a bit of a disconnect between inputs and holdings at the moment; holdings are far more "raw" and you read/write them unprocessed, specifying the exact register. In comparison inputs are processed into more "human friendly" values and batched out as part of `inputs/1` `inputs/2` and `inputs/3` messages, which is mostly an early design decision from when I only really cared about getting the power data into MQTT and had little knowledge of how the registers were laid out.

This PR adds more direct raw access to input registers, so now you can do `lxp/cmd/all/read/input/10` to get the instant battery charge power and get the raw register result in MQTT.

This also means that sending `lxp/cmd/all/read/input/0` with a payload of `40` is identical to sending `lxp/cmd/all/read/inputs/1`, so the new topic could eventually supercede the old one.

The processed JSON datadumps are still sent out when the appropriate packets are received (registers 0-39, 40-79, and 80-119 - or on newer inverters, 0-127).

Few considerations with this:

* it gets quite spammy in MQTT because there's 120 publishes every 5 minutes when the usual automated power data gets sent out from the inverter. For this reason, I've added a new `publish_individual_input` configuration option, defaulting to off for now.
* could be confusing that `cmd/read/input` returns unprocessed registers but `cmd/read/inputs` returns processed JSON. (and similarly that `lxp/datalog/input/1` is raw integers, but `lxp/datalog/inputs/1` is processed JSON.

Ultimately it's probably not that useful to read a single input register anyway when you can read 40 at a time, but I think having this in for completeness is a good idea.