### PR TITLE
Add WriteParam functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fix crash in scheduler during DST transition times (#107)
 * Add read individual input command and optional publishing of individual input registers (#111)
 * [Internal Cleanup] Use signed integers for inverter registers/values (#115)
+* Add WriteParam functionality (lxp/cmd/all/set/param/X) (#117)
 
 
 # 0.9.0 - 2nd November 2022

--- a/src/command.rs
+++ b/src/command.rs
@@ -7,6 +7,7 @@ pub enum Command {
     ReadHold(config::Inverter, i16, i16),
     ReadParam(config::Inverter, i16),
     SetHold(config::Inverter, i16, i16),
+    WriteParam(config::Inverter, i16, i16),
     ChargeRate(config::Inverter, i16),
     DischargeRate(config::Inverter, i16),
     AcCharge(config::Inverter, bool),
@@ -33,6 +34,9 @@ impl Command {
             }
             SetHold(inverter, register, _) => {
                 format!("{}/set/hold/{}", inverter.datalog(), register)
+            }
+            WriteParam(inverter, register, _) => {
+                format!("{}/set/param/{}", inverter.datalog(), register)
             }
             AcCharge(inverter, _) => format!("{}/set/ac_charge", inverter.datalog()),
             ForcedDischarge(inverter, _) => format!("{}/set/forced_discharge", inverter.datalog()),

--- a/src/coordinator/commands/mod.rs
+++ b/src/coordinator/commands/mod.rs
@@ -4,3 +4,4 @@ pub mod read_param;
 pub mod set_hold;
 pub mod timesync;
 pub mod update_hold;
+pub mod write_param;

--- a/src/coordinator/commands/write_param.rs
+++ b/src/coordinator/commands/write_param.rs
@@ -1,0 +1,55 @@
+use crate::prelude::*;
+
+use lxp::inverter::WaitForReply;
+
+pub struct WriteParam {
+    channels: Channels,
+    inverter: config::Inverter,
+    register: i16,
+    value: i16,
+}
+
+impl WriteParam {
+    pub fn new<U>(channels: Channels, inverter: config::Inverter, register: U, value: i16) -> Self
+    where
+        U: Into<i16>,
+    {
+        Self {
+            channels,
+            inverter,
+            register: register.into(),
+            value,
+        }
+    }
+
+    pub async fn run(&self) -> Result<Packet> {
+        let packet = Packet::WriteParam(lxp::packet::WriteParam {
+            datalog: self.inverter.datalog(),
+            register: self.register,
+            values: self.value.to_le_bytes().to_vec(),
+        });
+
+        let mut receiver = self.channels.from_inverter.subscribe();
+
+        if self
+            .channels
+            .to_inverter
+            .send(lxp::inverter::ChannelData::Packet(packet.clone()))
+            .is_err()
+        {
+            bail!("send(to_inverter) failed - channel closed?");
+        }
+
+        let packet = receiver.wait_for_reply(&packet).await?;
+        if packet.value() != self.value {
+            bail!(
+                "failed to set register {}, got back value {} (wanted {})",
+                self.register,
+                packet.value(),
+                self.value
+            );
+        }
+
+        Ok(packet)
+    }
+}

--- a/src/coordinator/commands/write_param.rs
+++ b/src/coordinator/commands/write_param.rs
@@ -41,13 +41,9 @@ impl WriteParam {
         }
 
         let packet = receiver.wait_for_reply(&packet).await?;
-        if packet.value() != self.value {
-            bail!(
-                "failed to set register {}, got back value {} (wanted {})",
-                self.register,
-                packet.value(),
-                self.value
-            );
+        // WriteParam packets seem to reply with 0 on success, very odd
+        if packet.value() != 0 {
+            bail!("failed to set register {}", self.register,);
         }
 
         Ok(packet)

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -92,6 +92,9 @@ impl Coordinator {
             ReadHold(inverter, register, count) => self.read_hold(inverter, register, count).await,
             ReadParam(inverter, register) => self.read_param(inverter, register).await,
             SetHold(inverter, register, value) => self.set_hold(inverter, register, value).await,
+            WriteParam(inverter, register, value) => {
+                self.write_param(inverter, register, value).await
+            }
             AcCharge(inverter, enable) => {
                 self.update_hold(
                     inverter,
@@ -180,6 +183,27 @@ impl Coordinator {
         commands::read_param::ReadParam::new(self.channels.clone(), inverter.clone(), register)
             .run()
             .await?;
+
+        Ok(())
+    }
+
+    async fn write_param<U>(
+        &self,
+        inverter: config::Inverter,
+        register: U,
+        value: i16,
+    ) -> Result<()>
+    where
+        U: Into<i16>,
+    {
+        commands::write_param::WriteParam::new(
+            self.channels.clone(),
+            inverter.clone(),
+            register,
+            value,
+        )
+        .run()
+        .await?;
 
         Ok(())
     }

--- a/src/lxp/inverter.rs
+++ b/src/lxp/inverter.rs
@@ -49,6 +49,11 @@ impl WaitForReply for Receiver {
                         return Ok(Packet::ReadParam(reply));
                     }
                 }
+                (Packet::WriteParam(wp), Ok(ChannelData::Packet(Packet::WriteParam(reply)))) => {
+                    if wp.datalog == reply.datalog && wp.register == reply.register {
+                        return Ok(Packet::WriteParam(reply));
+                    }
+                }
                 (_, Ok(ChannelData::Packet(_))) => {} // TODO ReadParam and WriteParam
                 (_, Ok(ChannelData::Disconnect(inverter_datalog))) => {
                     if inverter_datalog == packet.datalog() {

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -108,7 +108,9 @@ impl Message {
             }
             ["read", "param", register] => ReadParam(inverter, register.parse()?),
             ["set", "hold", register] => SetHold(inverter, register.parse()?, self.payload_int()?),
-            // TODO: set param
+            ["set", "param", register] => {
+                WriteParam(inverter, register.parse()?, self.payload_int()?)
+            }
             ["set", "ac_charge"] => AcCharge(inverter, self.payload_bool()),
 
             ["set", "forced_discharge"] => ForcedDischarge(inverter, self.payload_bool()),


### PR DESCRIPTION
This has been verified to work ~but the result topic is always a `FAIL`~ (now fixed) because WriteParam apparently doesn't return the new value of the register. It returns 0 on success and 1 on fail.

This is weird, if anything I could have understood it being the other way around, ie return 1 on success to mean 1 register has been updated, and 0 on failure to mean no registers were updated. 🤷 

I'm tempted to just do away with `result` topics, I doubt anyone uses them and wouldn't even notice. The preferred way to check if a set has succeeded should be to do a subsequent read of the same register and check the new value has persisted.

Closes #22