### PR TITLE
Revert some i16 changes

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -3,18 +3,18 @@ use crate::prelude::*;
 #[derive(Debug)]
 pub enum Command {
     ReadInputs(config::Inverter, i16),
-    ReadInput(config::Inverter, i16, i16),
-    ReadHold(config::Inverter, i16, i16),
+    ReadInput(config::Inverter, i16, u16),
+    ReadHold(config::Inverter, i16, u16),
     ReadParam(config::Inverter, i16),
-    SetHold(config::Inverter, i16, i16),
-    WriteParam(config::Inverter, i16, i16),
-    ChargeRate(config::Inverter, i16),
-    DischargeRate(config::Inverter, i16),
+    SetHold(config::Inverter, i16, u16),
+    WriteParam(config::Inverter, i16, u16),
+    ChargeRate(config::Inverter, u16),
+    DischargeRate(config::Inverter, u16),
     AcCharge(config::Inverter, bool),
     ForcedDischarge(config::Inverter, bool),
-    AcChargeRate(config::Inverter, i16),
-    AcChargeSocLimit(config::Inverter, i16),
-    DischargeCutoffSocLimit(config::Inverter, i16),
+    AcChargeRate(config::Inverter, u16),
+    AcChargeSocLimit(config::Inverter, u16),
+    DischargeCutoffSocLimit(config::Inverter, u16),
 }
 
 impl Command {

--- a/src/coordinator/commands/read_hold.rs
+++ b/src/coordinator/commands/read_hold.rs
@@ -9,11 +9,11 @@ pub struct ReadHold {
     channels: Channels,
     inverter: config::Inverter,
     register: i16,
-    count: i16,
+    count: u16,
 }
 
 impl ReadHold {
-    pub fn new<U>(channels: Channels, inverter: config::Inverter, register: U, count: i16) -> Self
+    pub fn new<U>(channels: Channels, inverter: config::Inverter, register: U, count: u16) -> Self
     where
         U: Into<i16>,
     {

--- a/src/coordinator/commands/read_inputs.rs
+++ b/src/coordinator/commands/read_inputs.rs
@@ -9,11 +9,11 @@ pub struct ReadInputs {
     channels: Channels,
     inverter: config::Inverter,
     register: i16,
-    count: i16,
+    count: u16,
 }
 
 impl ReadInputs {
-    pub fn new<U>(channels: Channels, inverter: config::Inverter, register: U, count: i16) -> Self
+    pub fn new<U>(channels: Channels, inverter: config::Inverter, register: U, count: u16) -> Self
     where
         U: Into<i16>,
     {

--- a/src/coordinator/commands/set_hold.rs
+++ b/src/coordinator/commands/set_hold.rs
@@ -9,11 +9,11 @@ pub struct SetHold {
     channels: Channels,
     inverter: config::Inverter,
     register: i16,
-    value: i16,
+    value: u16,
 }
 
 impl SetHold {
-    pub fn new<U>(channels: Channels, inverter: config::Inverter, register: U, value: i16) -> Self
+    pub fn new<U>(channels: Channels, inverter: config::Inverter, register: U, value: u16) -> Self
     where
         U: Into<i16>,
     {

--- a/src/coordinator/commands/update_hold.rs
+++ b/src/coordinator/commands/update_hold.rs
@@ -57,9 +57,9 @@ impl UpdateHold {
         let packet = receiver.wait_for_reply(&packet).await?;
         let bit = i16::from(self.bit.clone());
         let value = if self.enable {
-            packet.value() | bit
+            packet.value() | (bit as u16)
         } else {
-            packet.value() & !bit
+            packet.value() & !(bit as u16)
         };
 
         // new packet to set register with a new value

--- a/src/coordinator/commands/write_param.rs
+++ b/src/coordinator/commands/write_param.rs
@@ -6,11 +6,11 @@ pub struct WriteParam {
     channels: Channels,
     inverter: config::Inverter,
     register: i16,
-    value: i16,
+    value: u16,
 }
 
 impl WriteParam {
-    pub fn new<U>(channels: Channels, inverter: config::Inverter, register: U, value: i16) -> Self
+    pub fn new<U>(channels: Channels, inverter: config::Inverter, register: U, value: u16) -> Self
     where
         U: Into<i16>,
     {
@@ -43,7 +43,7 @@ impl WriteParam {
         let packet = receiver.wait_for_reply(&packet).await?;
         // WriteParam packets seem to reply with 0 on success, very odd
         if packet.value() != 0 {
-            bail!("failed to set register {}", self.register,);
+            bail!("failed to set register {}", self.register);
         }
 
         Ok(packet)

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -143,7 +143,7 @@ impl Coordinator {
         &self,
         inverter: config::Inverter,
         register: U,
-        count: i16,
+        count: u16,
     ) -> Result<()>
     where
         U: Into<i16>,
@@ -160,7 +160,7 @@ impl Coordinator {
         Ok(())
     }
 
-    async fn read_hold<U>(&self, inverter: config::Inverter, register: U, count: i16) -> Result<()>
+    async fn read_hold<U>(&self, inverter: config::Inverter, register: U, count: u16) -> Result<()>
     where
         U: Into<i16>,
     {
@@ -191,7 +191,7 @@ impl Coordinator {
         &self,
         inverter: config::Inverter,
         register: U,
-        value: i16,
+        value: u16,
     ) -> Result<()>
     where
         U: Into<i16>,
@@ -208,7 +208,7 @@ impl Coordinator {
         Ok(())
     }
 
-    async fn set_hold<U>(&self, inverter: config::Inverter, register: U, value: i16) -> Result<()>
+    async fn set_hold<U>(&self, inverter: config::Inverter, register: U, value: u16) -> Result<()>
     where
         U: Into<i16>,
     {

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -559,7 +559,7 @@ pub trait PacketCommon {
     fn register(&self) -> i16 {
         unimplemented!("register() not implemented");
     }
-    fn value(&self) -> i16 {
+    fn value(&self) -> u16 {
         unimplemented!("value() not implemented");
     }
 }
@@ -675,11 +675,11 @@ pub struct TranslatedData {
     pub values: Vec<u8>,                 // undecoded, since can be i16 or u32s?
 }
 impl TranslatedData {
-    pub fn pairs(&self) -> Vec<(i16, i16)> {
+    pub fn pairs(&self) -> Vec<(i16, u16)> {
         self.values
             .chunks(2)
             .enumerate()
-            .map(|(pos, value)| (self.register + pos as i16, Utils::i16ify(value, 0)))
+            .map(|(pos, value)| (self.register + pos as i16, Utils::u16ify(value, 0)))
             .collect()
     }
 
@@ -886,8 +886,8 @@ impl PacketCommon for TranslatedData {
         self.register
     }
 
-    fn value(&self) -> i16 {
-        Utils::i16ify(&self.values, 0)
+    fn value(&self) -> u16 {
+        Utils::u16ify(&self.values, 0)
     }
 }
 
@@ -982,8 +982,8 @@ impl PacketCommon for ReadParam {
         self.register
     }
 
-    fn value(&self) -> i16 {
-        Utils::i16ify(&self.values, 0)
+    fn value(&self) -> u16 {
+        Utils::u16ify(&self.values, 0)
     }
 }
 
@@ -1091,8 +1091,8 @@ impl PacketCommon for WriteParam {
         self.register
     }
 
-    fn value(&self) -> i16 {
-        Utils::i16ify(&self.values, 0)
+    fn value(&self) -> u16 {
+        Utils::u16ify(&self.values, 0)
     }
 }
 

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -154,11 +154,11 @@ impl Message {
         }
     }
 
-    pub fn payload_int_or_1(&self) -> Result<i16> {
+    pub fn payload_int_or_1(&self) -> Result<u16> {
         self.payload_int().or(Ok(1))
     }
 
-    pub fn payload_int(&self) -> Result<i16> {
+    pub fn payload_int(&self) -> Result<u16> {
         self.payload
             .parse()
             .map_err(|err| anyhow!("payload_int: {}", err))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,6 +9,9 @@ impl Utils {
     pub fn i16ify(array: &[u8], offset: usize) -> i16 {
         i16::from_le_bytes([array[offset], array[offset + 1]])
     }
+    pub fn u16ify(array: &[u8], offset: usize) -> u16 {
+        u16::from_le_bytes([array[offset], array[offset + 1]])
+    }
 
     pub fn le_i16_div10(input: &[u8]) -> nom::IResult<&[u8], f64> {
         let (input, num) = nom::number::complete::le_i16(input)?;

--- a/tests/test_coordinator_commands_read_hold.rs
+++ b/tests/test_coordinator_commands_read_hold.rs
@@ -9,7 +9,7 @@ async fn happy_path() {
     let channels = Channels::new();
 
     let register = 0 as i16;
-    let count = 40 as i16;
+    let count = 40 as u16;
 
     let subject = coordinator::commands::read_hold::ReadHold::new(
         channels.clone(),
@@ -51,7 +51,7 @@ async fn no_reply() {
     let channels = Channels::new();
 
     let register = 0 as i16;
-    let count = 40 as i16;
+    let count = 40 as u16;
 
     let subject = coordinator::commands::read_hold::ReadHold::new(
         channels.clone(),
@@ -85,7 +85,7 @@ async fn inverter_not_receiving() {
     let channels = Channels::new();
 
     let register = 0 as i16;
-    let count = 40 as i16;
+    let count = 40 as u16;
 
     let subject = coordinator::commands::read_hold::ReadHold::new(
         channels.clone(),

--- a/tests/test_coordinator_commands_read_inputs.rs
+++ b/tests/test_coordinator_commands_read_inputs.rs
@@ -9,7 +9,7 @@ async fn happy_path() {
     let channels = Channels::new();
 
     let register = 0 as i16;
-    let count = 40 as i16;
+    let count = 40 as u16;
 
     let subject = coordinator::commands::read_inputs::ReadInputs::new(
         channels.clone(),

--- a/tests/test_coordinator_commands_set_hold.rs
+++ b/tests/test_coordinator_commands_set_hold.rs
@@ -9,7 +9,7 @@ async fn happy_path() {
     let channels = Channels::new();
 
     let register = 5 as i16;
-    let value = 10 as i16;
+    let value = 10 as u16;
 
     let subject = coordinator::commands::set_hold::SetHold::new(
         channels.clone(),
@@ -51,7 +51,7 @@ async fn bad_reply() {
     let channels = Channels::new();
 
     let register = 5 as i16;
-    let value = 10 as i16;
+    let value = 10 as u16;
 
     let subject = coordinator::commands::set_hold::SetHold::new(
         channels.clone(),
@@ -96,7 +96,7 @@ async fn no_reply() {
     let channels = Channels::new();
 
     let register = 5 as i16;
-    let value = 10 as i16;
+    let value = 10 as u16;
 
     let subject = coordinator::commands::set_hold::SetHold::new(
         channels.clone(),
@@ -130,7 +130,7 @@ async fn inverter_not_receiving() {
     let channels = Channels::new();
 
     let register = 5 as i16;
-    let value = 10 as i16;
+    let value = 10 as u16;
 
     let subject = coordinator::commands::set_hold::SetHold::new(
         channels.clone(),


### PR DESCRIPTION
Went a bit overboard, forgetting that some code uses two i16 to create MQTT replies which won't always fit in an i16