### PR TITLE
feat: better Home Assistant MQTT structure and data

### DIFF
--- a/src/home_assistant.rs
+++ b/src/home_assistant.rs
@@ -289,14 +289,12 @@ impl Config {
     }
 
     fn device(inverter: &config::Inverter) -> ConfigDevice {
-        let device = ConfigDevice {
+        ConfigDevice {
             identifiers: [
                 format!("lxp_{}", inverter.datalog()),
             ],
             manufacturer: "LuxPower".to_owned(),
             name: format!("lxp_{}", inverter.datalog()),
-        };
-
-        return device;
+        }
     }
 }

--- a/src/home_assistant.rs
+++ b/src/home_assistant.rs
@@ -3,6 +3,14 @@ use crate::prelude::*;
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
+pub struct ConfigDevice {
+    manufacturer: String,
+    name: String,
+    identifiers: [String; 1],
+    // model: String, // TODO: provide inverter model
+}
+
+#[derive(Debug, Serialize)]
 pub struct Config {
     device_class: String,
     name: String,
@@ -11,6 +19,7 @@ pub struct Config {
     value_template: String,
     unit_of_measurement: String,
     unique_id: String,
+    device: ConfigDevice,
 }
 
 impl Config {
@@ -112,11 +121,12 @@ impl Config {
             ),
             unique_id: format!("lxp_{}_{}", inverter.datalog(), name),
             name: label.to_string(),
+            device: Self::device(inverter),
         };
 
         Ok(Some(mqtt::Message {
             topic: format!(
-                "{}/sensor/{}_{}/config",
+                "{}/sensor/lxp_{}/{}/config",
                 mqtt_config.homeassistant().prefix(),
                 inverter.datalog(),
                 name
@@ -147,11 +157,12 @@ impl Config {
             ),
             unique_id: format!("lxp_{}_{}", inverter.datalog(), name),
             name: label.to_string(),
+            device: Self::device(inverter),
         };
 
         Ok(Some(mqtt::Message {
             topic: format!(
-                "{}/sensor/{}_{}/config",
+                "{}/sensor/lxp_{}/{}/config",
                 mqtt_config.homeassistant().prefix(),
                 inverter.datalog(),
                 name
@@ -182,11 +193,12 @@ impl Config {
             ),
             unique_id: format!("lxp_{}_{}", inverter.datalog(), name),
             name: label.to_string(),
+            device: Self::device(inverter),
         };
 
         Ok(Some(mqtt::Message {
             topic: format!(
-                "{}/sensor/{}_{}/config",
+                "{}/sensor/lxp_{}/{}/config",
                 mqtt_config.homeassistant().prefix(),
                 inverter.datalog(),
                 name
@@ -217,11 +229,12 @@ impl Config {
             ),
             unique_id: format!("lxp_{}_{}", inverter.datalog(), name),
             name: label.to_string(),
+            device: Self::device(inverter),
         };
 
         Ok(Some(mqtt::Message {
             topic: format!(
-                "{}/sensor/{}_{}/config",
+                "{}/sensor/lxp_{}/{}/config",
                 mqtt_config.homeassistant().prefix(),
                 inverter.datalog(),
                 name
@@ -253,11 +266,12 @@ impl Config {
             ),
             unique_id: format!("lxp_{}_{}", inverter.datalog(), name),
             name: label.to_string(),
+            device: Self::device(inverter),
         };
 
         Ok(Some(mqtt::Message {
             topic: format!(
-                "{}/sensor/{}_{}/config",
+                "{}/sensor/lxp_{}/{}/config",
                 mqtt_config.homeassistant().prefix(),
                 inverter.datalog(),
                 name
@@ -272,5 +286,17 @@ impl Config {
             .iter()
             .map(|s| s.replace(' ', ""))
             .any(|s| s == "all" || s == name)
+    }
+
+    fn device(inverter: &config::Inverter) -> ConfigDevice {
+        let device = ConfigDevice {
+            identifiers: [
+                format!("lxp_{}", inverter.datalog()),
+            ],
+            manufacturer: "LuxPower".to_owned(),
+            name: format!("lxp_{}", inverter.datalog()),
+        };
+
+        return device;
     }
 }


### PR DESCRIPTION
### Improve Home Assistant MQTT structure 

#### Group Inverter data as device

Possibly breaking change for HA users

P. S. as bonus now it's easier to handle multiple inverters in HA #97 

<img width="1101" alt="Знімок екрана 2022-11-26 о 14 17 08" src="https://user-images.githubusercontent.com/3236466/204088498-8485ac3b-f914-4e5c-9aff-0c90d1e19f55.png">

<img width="573" alt="Знімок екрана 2022-11-26 о 14 17 34" src="https://user-images.githubusercontent.com/3236466/204088517-1a201259-4209-411a-a2ae-573b9edfdd22.png">
