### PR TITLE
Add forced_discharge MQTT message, and rename forced_charge -> charge_priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Decode bits in holding registers 21 and 110 and publish to `lxp/$datalog/hold/21/bits` (#119)
 * Better HomeAssistant discovery message structure (#120, @unreadablename)
 * Add MQTT messages to easily read/set time registers (#123)
+* Add missing `lxp/cmd/$datalog/set/forced_discharge` (#125)
 
 
 # 0.9.0 - 2nd November 2022

--- a/src/command.rs
+++ b/src/command.rs
@@ -7,16 +7,17 @@ pub enum Command {
     ReadHold(config::Inverter, i16, u16),
     ReadParam(config::Inverter, i16),
     ReadAcChargeTime(config::Inverter, i16),
-    ReadForcedChargeTime(config::Inverter, i16),
+    ReadChargePriorityTime(config::Inverter, i16),
     ReadForcedDischargeTime(config::Inverter, i16),
     SetHold(config::Inverter, i16, u16),
     WriteParam(config::Inverter, i16, u16),
     SetAcChargeTime(config::Inverter, i16, [u8; 4]),
-    SetForcedChargeTime(config::Inverter, i16, [u8; 4]),
+    SetChargePriorityTime(config::Inverter, i16, [u8; 4]),
     SetForcedDischargeTime(config::Inverter, i16, [u8; 4]),
     ChargeRate(config::Inverter, u16),
     DischargeRate(config::Inverter, u16),
     AcCharge(config::Inverter, bool),
+    ChargePriority(config::Inverter, bool),
     ForcedDischarge(config::Inverter, bool),
     AcChargeRate(config::Inverter, u16),
     AcChargeSocLimit(config::Inverter, u16),
@@ -41,8 +42,8 @@ impl Command {
             ReadAcChargeTime(inverter, num) => {
                 format!("{}/read/ac_charge/{}", inverter.datalog(), num)
             }
-            ReadForcedChargeTime(inverter, num) => {
-                format!("{}/read/forced_charge/{}", inverter.datalog(), num)
+            ReadChargePriorityTime(inverter, num) => {
+                format!("{}/read/charge_priority/{}", inverter.datalog(), num)
             }
             ReadForcedDischargeTime(inverter, num) => {
                 format!("{}/read/forced_discharge/{}", inverter.datalog(), num)
@@ -56,13 +57,14 @@ impl Command {
             SetAcChargeTime(inverter, num, _) => {
                 format!("{}/set/ac_charge/{}", inverter.datalog(), num)
             }
-            SetForcedChargeTime(inverter, num, _) => {
-                format!("{}/set/forced_charge/{}", inverter.datalog(), num)
+            SetChargePriorityTime(inverter, num, _) => {
+                format!("{}/set/charge_priority/{}", inverter.datalog(), num)
             }
             SetForcedDischargeTime(inverter, num, _) => {
                 format!("{}/set/forced_discharge/{}", inverter.datalog(), num)
             }
             AcCharge(inverter, _) => format!("{}/set/ac_charge", inverter.datalog()),
+            ChargePriority(inverter, _) => format!("{}/set/forced_harge", inverter.datalog()),
             ForcedDischarge(inverter, _) => format!("{}/set/forced_discharge", inverter.datalog()),
             ChargeRate(inverter, _) => format!("{}/set/charge_rate_pct", inverter.datalog()),
             DischargeRate(inverter, _) => format!("{}/set/discharge_rate_pct", inverter.datalog()),

--- a/src/command.rs
+++ b/src/command.rs
@@ -64,7 +64,7 @@ impl Command {
                 format!("{}/set/forced_discharge/{}", inverter.datalog(), num)
             }
             AcCharge(inverter, _) => format!("{}/set/ac_charge", inverter.datalog()),
-            ChargePriority(inverter, _) => format!("{}/set/forced_harge", inverter.datalog()),
+            ChargePriority(inverter, _) => format!("{}/set/charge_priority", inverter.datalog()),
             ForcedDischarge(inverter, _) => format!("{}/set/forced_discharge", inverter.datalog()),
             ChargeRate(inverter, _) => format!("{}/set/charge_rate_pct", inverter.datalog()),
             DischargeRate(inverter, _) => format!("{}/set/discharge_rate_pct", inverter.datalog()),

--- a/src/coordinator/commands/time_register_ops.rs
+++ b/src/coordinator/commands/time_register_ops.rs
@@ -21,7 +21,7 @@ struct MqttReplyPayload {
 
 pub enum Action {
     AcCharge(i16),
-    ForcedCharge(i16),
+    ChargePriority(i16),
     ForcedDischarge(i16),
 }
 
@@ -32,9 +32,9 @@ impl Action {
             AcCharge(1) => Ok(68),
             AcCharge(2) => Ok(70),
             AcCharge(3) => Ok(72),
-            ForcedCharge(1) => Ok(76),
-            ForcedCharge(2) => Ok(78),
-            ForcedCharge(3) => Ok(80),
+            ChargePriority(1) => Ok(76),
+            ChargePriority(2) => Ok(78),
+            ChargePriority(3) => Ok(80),
             ForcedDischarge(1) => Ok(84),
             ForcedDischarge(2) => Ok(86),
             ForcedDischarge(3) => Ok(88),
@@ -47,7 +47,7 @@ impl Action {
         // no need to be defensive about n here, we checked it already in register()
         match self {
             AcCharge(n) => format!("{}/ac_charge/{}", datalog, n),
-            ForcedCharge(n) => format!("{}/forced_charge/{}", datalog, n),
+            ChargePriority(n) => format!("{}/charge_priority/{}", datalog, n),
             ForcedDischarge(n) => format!("{}/forced_discharge/{}", datalog, n),
         }
     }

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -96,8 +96,8 @@ impl Coordinator {
                 self.read_time_register(inverter, Action::AcCharge(num))
                     .await
             }
-            ReadForcedChargeTime(inverter, num) => {
-                self.read_time_register(inverter, Action::ForcedCharge(num))
+            ReadChargePriorityTime(inverter, num) => {
+                self.read_time_register(inverter, Action::ChargePriority(num))
                     .await
             }
             ReadForcedDischargeTime(inverter, num) => {
@@ -112,8 +112,8 @@ impl Coordinator {
                 self.set_time_register(inverter, Action::AcCharge(num), values)
                     .await
             }
-            SetForcedChargeTime(inverter, num, values) => {
-                self.set_time_register(inverter, Action::ForcedCharge(num), values)
+            SetChargePriorityTime(inverter, num, values) => {
+                self.set_time_register(inverter, Action::ChargePriority(num), values)
                     .await
             }
             SetForcedDischargeTime(inverter, num, values) => {
@@ -129,6 +129,16 @@ impl Coordinator {
                 )
                 .await
             }
+            ChargePriority(inverter, enable) => {
+                self.update_hold(
+                    inverter,
+                    Register::Register21,
+                    RegisterBit::ChargePriorityEnable,
+                    enable,
+                )
+                .await
+            }
+
             ForcedDischarge(inverter, enable) => {
                 self.update_hold(
                     inverter,

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -544,6 +544,7 @@ pub enum RegisterBit {
     // Register 21
     AcChargeEnable = 1 << 7,
     ForcedDischargeEnable = 1 << 10,
+    ChargePriorityEnable = 1 << 11,
 }
 
 // Register21Bits {{{
@@ -560,7 +561,7 @@ pub struct Register21Bits {
     pub sw_seamless_en: bool,
     pub set_to_standby: bool,
     pub forced_discharge_en: bool,
-    pub forced_charge_en: bool,
+    pub charge_priority_en: bool,
     pub iso_en: bool,
     pub gfci_en: bool,
     pub dci_en: bool,
@@ -585,7 +586,7 @@ impl Register21Bits {
             sw_seamless_en: Self::is_bit_set(data, 1 << 8),
             set_to_standby: Self::is_bit_set(data, 1 << 9),
             forced_discharge_en: Self::is_bit_set(data, 1 << 10),
-            forced_charge_en: Self::is_bit_set(data, 1 << 1),
+            charge_priority_en: Self::is_bit_set(data, 1 << 1),
             iso_en: Self::is_bit_set(data, 1 << 12),
             gfci_en: Self::is_bit_set(data, 1 << 13),
             dci_en: Self::is_bit_set(data, 1 << 14),

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -124,7 +124,7 @@ impl Message {
             }
             ["read", "param", register] => ReadParam(inverter, register.parse()?),
             ["read", "ac_charge", num] => ReadAcChargeTime(inverter, num.parse()?),
-            ["read", "forced_charge", num] => ReadForcedChargeTime(inverter, num.parse()?),
+            ["read", "charge_priority", num] => ReadChargePriorityTime(inverter, num.parse()?),
             ["read", "forced_discharge", num] => ReadForcedDischargeTime(inverter, num.parse()?),
             ["set", "hold", register] => SetHold(inverter, register.parse()?, self.payload_int()?),
             ["set", "param", register] => {
@@ -134,13 +134,14 @@ impl Message {
             ["set", "ac_charge", num] => {
                 SetAcChargeTime(inverter, num.parse()?, self.payload_start_end_time()?)
             }
-            ["set", "forced_charge", num] => {
-                SetForcedChargeTime(inverter, num.parse()?, self.payload_start_end_time()?)
+            ["set", "charge_priority"] => ChargePriority(inverter, self.payload_bool()),
+            ["set", "charge_priority", num] => {
+                SetChargePriorityTime(inverter, num.parse()?, self.payload_start_end_time()?)
             }
+            ["set", "forced_discharge"] => ForcedDischarge(inverter, self.payload_bool()),
             ["set", "forced_discharge", num] => {
                 SetForcedDischargeTime(inverter, num.parse()?, self.payload_start_end_time()?)
             }
-            ["set", "forced_discharge"] => ForcedDischarge(inverter, self.payload_bool()),
             ["set", "charge_rate_pct"] => ChargeRate(inverter, self.payload_int()?),
             ["set", "discharge_rate_pct"] => DischargeRate(inverter, self.payload_int()?),
             ["set", "ac_charge_rate_pct"] => AcChargeRate(inverter, self.payload_int()?),

--- a/tests/test_mqtt_message.rs
+++ b/tests/test_mqtt_message.rs
@@ -62,7 +62,7 @@ async fn for_hold_21() {
     assert_eq!(
         mqtt::Message::for_hold(packet).unwrap(),
         vec![mqtt::Message { topic: "2222222222/hold/21".to_owned(), payload: "8716".to_owned() },
-             mqtt::Message { topic: "2222222222/hold/21/bits".to_owned(), payload: "{\"eps_en\":false,\"ovf_load_derate_en\":false,\"drms_en\":true,\"lvrt_en\":true,\"anti_island_en\":false,\"neutral_detect_en\":false,\"grid_on_power_ss_en\":false,\"ac_charge_en\":false,\"sw_seamless_en\":false,\"set_to_standby\":true,\"forced_discharge_en\":false,\"forced_charge_en\":false,\"iso_en\":false,\"gfci_en\":true,\"dci_en\":false,\"feed_in_grid_en\":false}".to_owned() }
+             mqtt::Message { topic: "2222222222/hold/21/bits".to_owned(), payload: "{\"eps_en\":false,\"ovf_load_derate_en\":false,\"drms_en\":true,\"lvrt_en\":true,\"anti_island_en\":false,\"neutral_detect_en\":false,\"grid_on_power_ss_en\":false,\"ac_charge_en\":false,\"sw_seamless_en\":false,\"set_to_standby\":true,\"forced_discharge_en\":false,\"charge_priority_en\":false,\"iso_en\":false,\"gfci_en\":true,\"dci_en\":false,\"feed_in_grid_en\":false}".to_owned() }
         ]
     );
 }


### PR DESCRIPTION
Adds missing forced_discharge message handling, closes #124 

Also semi-related, charge_priority matches what is on the Luxpower portal so to avoid confusion, rename it