### PR TITLE
feat(home-assistant): More data into Home Assistant

### DIFF
--- a/src/home_assistant.rs
+++ b/src/home_assistant.rs
@@ -36,6 +36,7 @@ impl Config {
             Self::voltage(inverter, mqtt_config, "v_bat", "Battery Voltage")?,
             Self::voltage(inverter, mqtt_config, "v_ac_r", "Grid Voltage")?,
             Self::frequency(inverter, mqtt_config, "f_ac", "Grid Frequency")?,
+            Self::frequency(inverter, mqtt_config, "f_eps", "EPS Frequency")?,
             Self::power(inverter, mqtt_config, "p_pv", "Power (PV Array)")?,
             Self::power(inverter, mqtt_config, "p_pv_1", "Power (PV String 1)")?,
             Self::power(inverter, mqtt_config, "p_pv_2", "Power (PV String 2)")?,
@@ -44,6 +45,7 @@ impl Config {
             Self::power(inverter, mqtt_config, "p_discharge", "Battery Discharge")?,
             Self::power(inverter, mqtt_config, "p_to_user", "Power from Grid")?,
             Self::power(inverter, mqtt_config, "p_to_grid", "Power to Grid")?,
+            Self::power(inverter, mqtt_config, "p_eps", "Active EPS Power")?,
             Self::energy(
                 inverter,
                 mqtt_config,

--- a/src/home_assistant.rs
+++ b/src/home_assistant.rs
@@ -35,6 +35,7 @@ impl Config {
             Self::voltage(inverter, mqtt_config, "v_pv_3", "Voltage (PV String 3)")?,
             Self::voltage(inverter, mqtt_config, "v_bat", "Battery Voltage")?,
             Self::voltage(inverter, mqtt_config, "v_ac_r", "Grid Voltage")?,
+            Self::frequency(inverter, mqtt_config, "f_ac", "Grid Frequency")?,
             Self::power(inverter, mqtt_config, "p_pv", "Power (PV Array)")?,
             Self::power(inverter, mqtt_config, "p_pv_1", "Power (PV String 1)")?,
             Self::power(inverter, mqtt_config, "p_pv_2", "Power (PV String 2)")?,
@@ -114,6 +115,42 @@ impl Config {
             device_class: "battery".to_owned(),
             state_class: "measurement".to_owned(),
             unit_of_measurement: "%".to_owned(),
+            value_template: format!("{{{{ value_json.{} }}}}", name),
+            state_topic: format!(
+                "{}/{}/inputs/all",
+                mqtt_config.namespace(),
+                inverter.datalog()
+            ),
+            unique_id: format!("lxp_{}_{}", inverter.datalog(), name),
+            name: label.to_string(),
+            device: Self::device(inverter),
+        };
+
+        Ok(Some(mqtt::Message {
+            topic: format!(
+                "{}/sensor/lxp_{}/{}/config",
+                mqtt_config.homeassistant().prefix(),
+                inverter.datalog(),
+                name
+            ),
+            payload: serde_json::to_string(&config)?,
+        }))
+    }
+
+    fn frequency(
+        inverter: &config::Inverter,
+        mqtt_config: &config::Mqtt,
+        name: &str,
+        label: &str,
+    ) -> Result<Option<mqtt::Message>> {
+        if !Self::sensor_enabled(mqtt_config.homeassistant().sensors(), name) {
+            return Ok(None);
+        }
+
+        let config = Self {
+            device_class: "frequency".to_owned(),
+            state_class: "measurement".to_owned(),
+            unit_of_measurement: "Hz".to_owned(),
             value_template: format!("{{{{ value_json.{} }}}}", name),
             state_topic: format!(
                 "{}/{}/inputs/all",

--- a/src/home_assistant.rs
+++ b/src/home_assistant.rs
@@ -34,6 +34,7 @@ impl Config {
             Self::voltage(inverter, mqtt_config, "v_pv_2", "Voltage (PV String 2)")?,
             Self::voltage(inverter, mqtt_config, "v_pv_3", "Voltage (PV String 3)")?,
             Self::voltage(inverter, mqtt_config, "v_bat", "Battery Voltage")?,
+            Self::voltage(inverter, mqtt_config, "v_ac_r", "Grid Voltage")?,
             Self::power(inverter, mqtt_config, "p_pv", "Power (PV Array)")?,
             Self::power(inverter, mqtt_config, "p_pv_1", "Power (PV String 1)")?,
             Self::power(inverter, mqtt_config, "p_pv_2", "Power (PV String 2)")?,

--- a/src/home_assistant.rs
+++ b/src/home_assistant.rs
@@ -28,6 +28,7 @@ impl Config {
         mqtt_config: &config::Mqtt,
     ) -> Result<Vec<mqtt::Message>> {
         let r = vec![
+            Self::apparent_power(inverter, mqtt_config, "s_eps", "Apparent EPS Power")?,
             Self::battery(inverter, mqtt_config, "soc", "Battery Percentage")?,
             Self::voltage(inverter, mqtt_config, "v_pv", "Voltage (PV Array)")?,
             Self::voltage(inverter, mqtt_config, "v_pv_1", "Voltage (PV String 1)")?,
@@ -103,6 +104,42 @@ impl Config {
 
         // drop all None
         Ok(r.into_iter().flatten().collect())
+    }
+
+    fn apparent_power(
+        inverter: &config::Inverter,
+        mqtt_config: &config::Mqtt,
+        name: &str,
+        label: &str,
+    ) -> Result<Option<mqtt::Message>> {
+        if !Self::sensor_enabled(mqtt_config.homeassistant().sensors(), name) {
+            return Ok(None);
+        }
+
+        let config = Self {
+            device_class: "apparent_power".to_owned(),
+            state_class: "measurement".to_owned(),
+            unit_of_measurement: "VA".to_owned(),
+            value_template: format!("{{{{ value_json.{} }}}}", name),
+            state_topic: format!(
+                "{}/{}/inputs/all",
+                mqtt_config.namespace(),
+                inverter.datalog()
+            ),
+            unique_id: format!("lxp_{}_{}", inverter.datalog(), name),
+            name: label.to_string(),
+            device: Self::device(inverter),
+        };
+
+        Ok(Some(mqtt::Message {
+            topic: format!(
+                "{}/sensor/lxp_{}/{}/config",
+                mqtt_config.homeassistant().prefix(),
+                inverter.datalog(),
+                name
+            ),
+            payload: serde_json::to_string(&config)?,
+        }))
     }
 
     fn battery(

--- a/src/home_assistant.rs
+++ b/src/home_assistant.rs
@@ -46,6 +46,8 @@ impl Config {
             Self::power(inverter, mqtt_config, "p_to_user", "Power from Grid")?,
             Self::power(inverter, mqtt_config, "p_to_grid", "Power to Grid")?,
             Self::power(inverter, mqtt_config, "p_eps", "Active EPS Power")?,
+            Self::power(inverter, mqtt_config, "p_charge", "Battery Charge Power")?,
+            Self::power(inverter, mqtt_config, "p_discharge", "Battery Discharge Power")?,
             Self::energy(
                 inverter,
                 mqtt_config,


### PR DESCRIPTION
#### Map more data into Home Assistant

- added `apparent_power` device class
- added `duration` device class
- added `frequency` device class

- added Grid Voltage and Frequency
- added EPS Active Power, Apparent Power and Frequency
- added Battery Charge and Discharge Power
- added Inverter Total Runtime

[Home Assistant Sensors Documentation](https://developers.home-assistant.io/docs/core/entity/sensor/)
