### PR TITLE
fix(home-assistant): Fix temperature units

### DIFF
--- a/src/home_assistant.rs
+++ b/src/home_assistant.rs
@@ -125,7 +125,7 @@ impl Config {
     }
 
     fn temperature(&self, name: &str, label: &str) -> Result<Option<mqtt::Message>> {
-        self.sensor(name, label, "temperature", "measurement", "C")
+        self.sensor(name, label, "temperature", "measurement", "°C")
     }
 
     fn sensor(


### PR DESCRIPTION
#### Fix temperature units

Proper temperature unit is `°C`

[Documentation](https://developers.home-assistant.io/docs/core/entity/sensor/)