### PR TITLE
Add inter-task notification system

### DIFF
--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -14,11 +14,16 @@ pub type InputsStore = std::collections::HashMap<Serial, lxp::packet::ReadInputs
 pub struct Coordinator {
     config: ConfigWrapper,
     channels: Channels,
+    notify: Notify,
 }
 
 impl Coordinator {
-    pub fn new(config: ConfigWrapper, channels: Channels) -> Self {
-        Self { config, channels }
+    pub fn new(config: ConfigWrapper, channels: Channels, notify: Notify) -> Self {
+        Self {
+            config,
+            channels,
+            notify,
+        }
     }
 
     pub async fn start(&self) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub async fn app() -> Result<()> {
     let channels = Channels::new();
 
     let scheduler = Scheduler::new(config.clone(), channels.clone());
-    let mqtt = Mqtt::new(config.clone(), channels.clone());
+    let mqtt = Mqtt::new(config.clone(), channels.clone(), notify.clone());
     let influx = Influx::new(config.clone(), channels.clone());
     let coordinator = Coordinator::new(config.clone(), channels.clone(), notify.clone());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod home_assistant;
 pub mod influx;
 pub mod lxp;
 pub mod mqtt;
+pub mod notify;
 pub mod options;
 pub mod prelude;
 pub mod scheduler;
@@ -36,6 +37,8 @@ pub async fn app() -> Result<()> {
 
     info!("lxp-bridge {} starting", CARGO_PKG_VERSION);
 
+    let notify = Notify::new();
+
     let config = ConfigWrapper::new(options.config_file)?;
 
     let channels = Channels::new();
@@ -43,7 +46,7 @@ pub async fn app() -> Result<()> {
     let scheduler = Scheduler::new(config.clone(), channels.clone());
     let mqtt = Mqtt::new(config.clone(), channels.clone());
     let influx = Influx::new(config.clone(), channels.clone());
-    let coordinator = Coordinator::new(config.clone(), channels.clone());
+    let coordinator = Coordinator::new(config.clone(), channels.clone(), notify.clone());
 
     let inverters = config
         .enabled_inverters()

--- a/src/lxp/inverter.rs
+++ b/src/lxp/inverter.rs
@@ -74,16 +74,12 @@ impl WaitForReply for Receiver {
 } // }}}
 
 // Serial {{{
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub struct Serial([u8; 10]);
 
 impl Serial {
     pub fn new(input: &[u8]) -> Result<Self> {
         Ok(Self(input.try_into()?))
-    }
-
-    pub fn default() -> Self {
-        Self([0; 10])
     }
 
     pub fn data(&self) -> [u8; 10] {

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -237,13 +237,15 @@ pub struct Mqtt {
     config: ConfigWrapper,
     shutdown: bool,
     channels: Channels,
+    notify: Notify,
 }
 
 impl Mqtt {
-    pub fn new(config: ConfigWrapper, channels: Channels) -> Self {
+    pub fn new(config: ConfigWrapper, channels: Channels, notify: Notify) -> Self {
         Self {
             config,
             channels,
+            notify,
             shutdown: false,
         }
     }
@@ -388,6 +390,8 @@ impl Mqtt {
         use ChannelData::*;
 
         let mut receiver = self.channels.to_mqtt.subscribe();
+
+        self.notify.mqtt_sender_is_ready();
 
         loop {
             match receiver.recv().await? {

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -1,0 +1,35 @@
+use crate::prelude::*;
+
+#[derive(Default, Clone)]
+pub struct Notify {
+    /* wrap everything in a single Rc, avoids having an Rc for each member */
+    inner: Rc<Inner>,
+}
+
+#[derive(Default)]
+struct Inner {
+    mqtt_sender_ready: RefCell<bool>,
+    mqtt_sender_notify: tokio::sync::Notify,
+}
+
+impl Notify {
+    pub fn new() -> Self {
+        Self {
+            inner: Rc::new(Inner::default()),
+        }
+    }
+
+    pub fn mqtt_sender_is_ready(&self) {
+        *self.inner.mqtt_sender_ready.borrow_mut() = true;
+
+        self.inner.mqtt_sender_notify.notify_waiters();
+    }
+
+    pub async fn wait_for_mqtt_sender(&self) {
+        if *self.inner.mqtt_sender_ready.borrow() {
+            return;
+        }
+
+        self.inner.mqtt_sender_notify.notified().await;
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -26,6 +26,7 @@ pub use crate::{
         packet::{Packet, PacketCommon},
     },
     mqtt::{self, Mqtt},
+    notify::Notify,
     options::Options,
     scheduler::Scheduler,
     unixtime::UnixTime,


### PR DESCRIPTION
To assist in #143, this will provide a mechanism for tasks to wait on each other before attempting to send messages down channels that may be closed.

Untested so far, but its simple enough..

This will of course break all the tests as `Coordinator` now has a new call signature.. and this will need passing into the other subsystems too eventually.