### PR TITLE
Set up channel receivers early

### DIFF
--- a/src/influx.rs
+++ b/src/influx.rs
@@ -11,16 +11,27 @@ pub enum ChannelData {
     Shutdown,
 }
 
+pub type Receiver = broadcast::Receiver<ChannelData>;
 pub type Sender = broadcast::Sender<ChannelData>;
 
 pub struct Influx {
     config: ConfigWrapper,
     channels: Channels,
+    receiver: Cell<Option<Receiver>>,
 }
 
 impl Influx {
     pub fn new(config: ConfigWrapper, channels: Channels) -> Self {
-        Self { config, channels }
+        // Create the receiver at new() time, rather than start(), so things
+        // wanting to send to queue messages, rather than failing with an error
+        // about closed channels
+        let receiver = Cell::new(Some(channels.to_influx.subscribe()));
+
+        Self {
+            config,
+            channels,
+            receiver,
+        }
     }
 
     pub async fn start(&self) -> Result<()> {
@@ -56,7 +67,7 @@ impl Influx {
     async fn sender(&self, client: Client) -> Result<()> {
         use ChannelData::*;
 
-        let mut receiver = self.channels.to_influx.subscribe();
+        let mut receiver = self.receiver.take().expect("should only be called once");
 
         loop {
             let mut line = LineBuilder::new(INPUTS_MEASUREMENT);

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,5 @@
 pub use std::{
-    cell::{Ref, RefCell, RefMut},
+    cell::{Cell, Ref, RefCell, RefMut},
     convert::{TryFrom, TryInto},
     io::Write,
     rc::Rc,

--- a/tests/test_inverter.rs
+++ b/tests/test_inverter.rs
@@ -112,8 +112,6 @@ async fn test_replies_to_heartbeats() {
     let channels = Channels::new();
     let inverter = lxp::inverter::Inverter::new(config, &inverter, channels.clone());
 
-    let from_inverter = channels.from_inverter.subscribe();
-
     let tf = async {
         // pretend to be an inverter
         let listener = tokio::net::TcpListener::bind("localhost:1235")


### PR DESCRIPTION
Problem identified while working on #143 ; this is my attempt at a fix. Another option exists in #144, and there may be other, better, ways too.

At present, components can race with each other and try to send a message on a channel before the other side has managed to set up their receiver. When this happens, an error is raised, which can lead to process termination.

Instead, set up all the receivers at the initialization stage (e.g. when calling new()). This requires some trickery to pass the mutable receiver down into the respective start() -> receive() methods, which is achieved with an option inside a cell. When the mutable receiver is consumed, it is replaced with a None value.

The stop methods of the various structs that need this all consume the reference (i.e. take &mut self), so there's no chance of the start() method being called a second time (leading to the `expect` calls being triggered).