### PR TITLE
Revert "Set up channel receivers early"

### DIFF
--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -2,8 +2,7 @@ use crate::prelude::*;
 
 pub mod commands;
 
-use lxp::inverter;
-use lxp::packet::{DeviceFunction, Register, TcpFunction};
+use lxp::packet::{DeviceFunction, TcpFunction};
 
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub enum ChannelData {
@@ -15,25 +14,11 @@ pub type InputsStore = std::collections::HashMap<Serial, lxp::packet::ReadInputs
 pub struct Coordinator {
     config: ConfigWrapper,
     channels: Channels,
-
-    inverter_receiver: Cell<Option<inverter::Receiver>>,
-    mqtt_receiver: Cell<Option<mqtt::Receiver>>,
 }
 
 impl Coordinator {
     pub fn new(config: ConfigWrapper, channels: Channels) -> Self {
-        // Create the receivers at new() time, rather than start(), so things
-        // wanting to send to us will queue messages instead of failing with an
-        // error about closed channels
-        let inverter_receiver = Cell::new(Some(channels.from_inverter.subscribe()));
-        let mqtt_receiver = Cell::new(Some(channels.from_mqtt.subscribe()));
-
-        Self {
-            config,
-            channels,
-            inverter_receiver,
-            mqtt_receiver,
-        }
+        Self { config, channels }
     }
 
     pub async fn start(&self) -> Result<()> {
@@ -52,10 +37,7 @@ impl Coordinator {
     }
 
     async fn mqtt_receiver(&self) -> Result<()> {
-        let mut receiver = self
-            .mqtt_receiver
-            .take()
-            .expect("should only be called once");
+        let mut receiver = self.channels.from_mqtt.subscribe();
 
         loop {
             match receiver.recv().await? {
@@ -97,7 +79,7 @@ impl Coordinator {
 
     async fn process_command(&self, command: Command) -> Result<()> {
         use commands::time_register_ops::Action;
-        use lxp::packet::RegisterBit;
+        use lxp::packet::{Register, RegisterBit};
         use Command::*;
 
         match command {
@@ -328,10 +310,7 @@ impl Coordinator {
     async fn inverter_receiver(&self) -> Result<()> {
         use lxp::inverter::ChannelData::*;
 
-        let mut receiver = self
-            .inverter_receiver
-            .take()
-            .expect("should only be called once");
+        let mut receiver = self.channels.from_inverter.subscribe();
 
         let mut inputs_store = InputsStore::new();
 

--- a/src/lxp/inverter.rs
+++ b/src/lxp/inverter.rs
@@ -130,7 +130,6 @@ pub struct Inverter {
     config: ConfigWrapper,
     host: String,
     channels: Channels,
-    receiver: Cell<Option<Receiver>>,
 }
 
 impl Inverter {
@@ -138,16 +137,10 @@ impl Inverter {
         // remember which inverter this instance is for
         let host = inverter.host().to_string();
 
-        // Create the receiver at new() time, rather than start(), so things
-        // wanting to send to the inverter queue messages, rather than failing
-        // with an error about closed channels
-        let receiver = Cell::new(Some(channels.to_inverter.subscribe()));
-
         Self {
             config,
             host,
             channels,
-            receiver,
         }
     }
 
@@ -254,7 +247,7 @@ impl Inverter {
 
     // coordinator -> inverter
     async fn sender(&self, mut socket: tokio::net::tcp::OwnedWriteHalf) -> Result<()> {
-        let mut receiver = self.receiver.take().expect("should only be called once");
+        let mut receiver = self.channels.to_inverter.subscribe();
 
         use ChannelData::*;
 

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -231,27 +231,19 @@ pub enum ChannelData {
     Shutdown,
 }
 
-pub type Receiver = broadcast::Receiver<ChannelData>;
 pub type Sender = broadcast::Sender<ChannelData>;
 
 pub struct Mqtt {
     config: ConfigWrapper,
     shutdown: bool,
     channels: Channels,
-    receiver: Cell<Option<Receiver>>,
 }
 
 impl Mqtt {
     pub fn new(config: ConfigWrapper, channels: Channels) -> Self {
-        // Create the receiver at new() time, rather than start(), so things
-        // wanting to send to MQTT queue messages, rather than failing with an
-        // error about closed channels
-        let receiver = Cell::new(Some(channels.to_mqtt.subscribe()));
-
         Self {
             config,
             channels,
-            receiver,
             shutdown: false,
         }
     }
@@ -395,7 +387,7 @@ impl Mqtt {
     async fn sender(&self, client: AsyncClient) -> Result<()> {
         use ChannelData::*;
 
-        let mut receiver = self.receiver.take().expect("should only be called once");
+        let mut receiver = self.channels.to_mqtt.subscribe();
 
         loop {
             match receiver.recv().await? {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,5 @@
 pub use std::{
-    cell::{Cell, Ref, RefCell, RefMut},
+    cell::{Ref, RefCell, RefMut},
     convert::{TryFrom, TryInto},
     io::Write,
     rc::Rc,

--- a/tests/test_inverter.rs
+++ b/tests/test_inverter.rs
@@ -112,6 +112,8 @@ async fn test_replies_to_heartbeats() {
     let channels = Channels::new();
     let inverter = lxp::inverter::Inverter::new(config, &inverter, channels.clone());
 
+    let from_inverter = channels.from_inverter.subscribe();
+
     let tf = async {
         // pretend to be an inverter
         let listener = tokio::net::TcpListener::bind("localhost:1235")


### PR DESCRIPTION
Reverts celsworth/lxp-bridge#145

Sorry @celsworth, I've just noticed a regression caused by this PR.

In `src/lxp/inverter.rs`, the flow is `start { while connect() { sender() } }`

Since we call `sender` in a loop, and since that's where the `take` is, any time the inverter reconnects, lxp-bridge dies with the error "should only be called once" :grimacing:

Best to revert the whole thing and maybe revisit once your integration test suite is in place :sweat_smile:

As it happens, I think I've got an approach to broadcasting the holding registers that doesn't need this PR anyway. I was working on that when I triggered this bug! Hopefully I'll have something to show tonight.