### PR TITLE
Send holding register data when connected to an inverter

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -5,12 +5,14 @@ inverters:
   serial: 5555555555
   datalog: 2222222222
   heartbeats: false
+  publish_holdings_on_connect: false
 - enabled: false
   host: 192.168.0.163
   port: 8000
   serial: 9999999999
   datalog: 3333333333
   heartbeats: false
+  publish_holdings_on_connect: false
 
 databases:
 - enabled: false

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,7 @@ pub struct Inverter {
     pub datalog: Serial,
 
     pub heartbeats: Option<bool>,
+    pub publish_holdings_on_connect: Option<bool>,
 }
 impl Inverter {
     pub fn enabled(&self) -> bool {
@@ -55,6 +56,10 @@ impl Inverter {
 
     pub fn heartbeats(&self) -> bool {
         self.heartbeats == Some(true)
+    }
+
+    pub fn publish_holdings_on_connect(&self) -> bool {
+        self.publish_holdings_on_connect == Some(true)
     }
 } // }}}
 
@@ -262,6 +267,13 @@ impl ConfigWrapper {
         self.inverters()
             .iter()
             .find(|inverter| inverter.host == host)
+            .cloned()
+    }
+
+    pub fn enabled_inverter_with_datalog(&self, datalog: Serial) -> Option<Inverter> {
+        self.enabled_inverters()
+            .iter()
+            .find(|inverter| inverter.datalog == datalog)
             .cloned()
     }
 

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -822,7 +822,7 @@ impl TranslatedData {
     fn decode(input: &[u8]) -> Result<Self> {
         let len = input.len();
         if len < 38 {
-            bail!("packet too short");
+            bail!("TranslatedData::decode packet too short");
         }
 
         let protocol = Utils::i16ify(input, 2);
@@ -991,7 +991,7 @@ impl ReadParam {
     fn decode(input: &[u8]) -> Result<Self> {
         let len = input.len();
         if len < 24 {
-            bail!("packet too short");
+            bail!("ReadParam::decode packet too short");
         }
 
         let protocol = Utils::i16ify(input, 2);
@@ -1087,7 +1087,7 @@ impl WriteParam {
     fn decode(input: &[u8]) -> Result<Self> {
         let len = input.len();
         if len < 21 {
-            bail!("packet too short");
+            bail!("WriteParam::decode packet too short");
         }
 
         let protocol = Utils::i16ify(input, 2);

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -22,6 +22,7 @@ impl Factory {
             datalog: Serial::from_str("2222222222").unwrap(),
             serial: Serial::from_str("5555555555").unwrap(),
             heartbeats: None,
+            publish_holdings_on_connect: None,
         }
     }
 

--- a/tests/test_config.rs
+++ b/tests/test_config.rs
@@ -26,6 +26,7 @@ fn inverter_defaults() {
     let inverter: config::Inverter = serde_json::from_value(input).unwrap();
     assert!(inverter.enabled());
     assert_eq!(inverter.heartbeats(), false);
+    assert_eq!(inverter.publish_holdings_on_connect(), false);
 }
 
 #[test]
@@ -36,6 +37,16 @@ fn inverter_heartbeats() {
     let input = json!({ "host": "host", "port": 8000, "serial": "TESTSERIAL", "datalog": "TESTDATALO", "heartbeats": true });
     let inverter: config::Inverter = serde_json::from_value(input).unwrap();
     assert_eq!(inverter.heartbeats(), true);
+}
+
+#[test]
+fn inverter_publish_holdings_on_connect() {
+    let input = json!({ "host": "host", "port": 8000, "serial": "TESTSERIAL", "datalog": "TESTDATALO", "publish_holdings_on_connect": false });
+    let inverter: config::Inverter = serde_json::from_value(input).unwrap();
+    assert_eq!(inverter.publish_holdings_on_connect(), false);
+    let input = json!({ "host": "host", "port": 8000, "serial": "TESTSERIAL", "datalog": "TESTDATALO", "publish_holdings_on_connect": true });
+    let inverter: config::Inverter = serde_json::from_value(input).unwrap();
+    assert_eq!(inverter.publish_holdings_on_connect(), true);
 }
 
 #[test]
@@ -74,6 +85,7 @@ fn enabled_inverters() {
             port: 8000,
             serial: example_serial(),
             heartbeats: None,
+            publish_holdings_on_connect: None,
         },
         config::Inverter {
             enabled: true,
@@ -82,6 +94,7 @@ fn enabled_inverters() {
             port: 8000,
             serial: example_serial(),
             heartbeats: None,
+            publish_holdings_on_connect: None,
         },
     ]);
 
@@ -100,6 +113,7 @@ fn inverters_for_message() {
             port: 8000,
             serial: example_serial(),
             heartbeats: None,
+            publish_holdings_on_connect: None,
         },
         config::Inverter {
             enabled: false,
@@ -108,6 +122,7 @@ fn inverters_for_message() {
             port: 8000,
             serial: example_serial(),
             heartbeats: None,
+            publish_holdings_on_connect: None,
         },
     ]);
 

--- a/tests/test_inverter.rs
+++ b/tests/test_inverter.rs
@@ -20,6 +20,7 @@ async fn serials_fixed_in_outgoing_packets() {
         datalog: Serial::from_str("0000000000").unwrap(),
         serial: Serial::from_str("0000000000").unwrap(),
         heartbeats: None,
+        publish_holdings_on_connect: None,
     };
     let channels = Channels::new();
     let inverter = lxp::inverter::Inverter::new(config, &inverter, channels.clone());
@@ -108,6 +109,7 @@ async fn test_replies_to_heartbeats() {
         datalog: Serial::from_str("XXXXXXXXXX").unwrap(),
         serial: Serial::from_str("0000000000").unwrap(),
         heartbeats: Some(true),
+        publish_holdings_on_connect: None,
     };
     let channels = Channels::new();
     let inverter = lxp::inverter::Inverter::new(config, &inverter, channels.clone());


### PR DESCRIPTION
This makes homeassistant far more pleasant to use, as the autodiscovery message `state_topic`s we've been adding in previous PRs now receive messages when lxp-bridge (re)connects to the inverter. This means that controls will generally show the correct value, rather than "unknown".

In #143 I trialled a version of this that would broadcast the holding registers when the lxp-bridge process started up. This caused issues as we might try to send on a channel before a subscriber had been connected; I tried to fix that in #145, but this turned out to be buggy and was reverted in #146.

By delaying the broadcasts until after we connect to the inverter, we ensure (as much as anything is sure in the current code) that the channels already have subscribers, so this problem doesn't arise. We also act better when lxp-bridge is acting as a long-lived process (which is very much the norm): if the network between lxp-bridge and inverter is down for a time, then as soon as it comes back up, lxp-bridge will rebroadcast the holding registers, including any values that changed while the network was down.

This still needs tests and a few tweaks, but it's looking good in my testing.