### PR TITLE
Fix crash in timesync during DST transition times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Remove v_pv inputs key (#135)
 * Remove mqtt.homeassistant.sensors configuration option (#132, @lupine)
 * Add HA discovery messages for number controls (AC Charge Cutoff % etc) (#132, @lupine)
+* Fix crash in timesync during DST transition times (#153)
 
 
 # 0.9.0 - 2nd November 2022

--- a/src/influx.rs
+++ b/src/influx.rs
@@ -71,7 +71,7 @@ impl Influx {
                             let value = value.as_i64().unwrap_or_else(|| {
                                 panic!("cannot represent {value} as i64 for {key}")
                             });
-                            line.set_timestamp(chrono::Utc.timestamp(value, 0))
+                            line.set_timestamp(chrono::Utc.timestamp_opt(value, 0).unwrap())
                         } else if key == "datalog" {
                             let value = value.as_str().unwrap_or_else(|| {
                                 panic!("cannot represent {value} as str for {key}")


### PR DESCRIPTION
This should fix the crash that happens if the timesync schedule fires during a DST transition.

The previous behaviour was to get the inverter time then construct a `chrono::Local` out of it. At certain times, specifically 2022-10-30 01:59 for example, this is ambiguous, because in the UK that time happens twice, once in BST then again in GMT, and chrono raises an exception about it. Note that the inverter doesn't store a timezone.

To try and fix this, we'll always use `Utc` to create the time object from the inverters time, and pretend it's Utc. Then we make a Utc object for the current time and add on the correct number of seconds to get it to represent the local time (but again, as Utc). Strictly speaking, these are now the wrong time, but they're wrong in equal amounts so are comparable for our purposes.

Fixes #105. Hopefully.