### PR TITLE
Another attempt at HA diagnostics (and refactor home_assistant.rs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Add more sensors to HomeAssistant autodiscovery (#181, @Sboshoff76)
 * Add `p_battery` and `p_grid` inputs keys to show net power flows (#183)
 * Avoid floating point maths oddities in e_pv_day and e_pv_all calculations (#185)
-* Add internal_fault/warning_code/fault_code keys (#189, #190)
+* Add internal_fault/warning_code/fault_code keys (#189, #190, #191)
 
 # 0.11.0 - 16th July 2023
 

--- a/src/home_assistant.rs
+++ b/src/home_assistant.rs
@@ -98,9 +98,9 @@ impl Config {
     pub fn all(&self) -> Result<Vec<mqtt::Message>> {
         let r = vec![
             self.diagnostic("status", "Status", "input/0/parsed")?,
-            self.diagnostic("internal_fault", "Internal Fault", "input/1/parsed")?,
-            self.diagnostic("warning_code", "Warning Code", "input/1/parsed")?,
-            self.diagnostic("fault_code", "Fault Code", "input/1/parsed")?,
+            self.diagnostic("internal_fault", "Internal Fault", "input/6/parsed")?,
+            self.diagnostic("fault_code", "Fault Code", "input/60/parsed")?, // actually 60 and 61
+            self.diagnostic("warning_code", "Warning Code", "input/62/parsed")?, // actually 62 and 63
             self.apparent_power("s_eps", "Apparent EPS Power")?,
             self.battery("soc", "Battery Percentage")?,
             self.duration("runtime", "Total Runtime")?,

--- a/src/home_assistant.rs
+++ b/src/home_assistant.rs
@@ -99,8 +99,8 @@ impl Config {
         let r = vec![
             self.diagnostic("status", "Status", "input/0/parsed")?,
             self.diagnostic("internal_fault", "Internal Fault", "input/6/parsed")?,
-            self.diagnostic("fault_code", "Fault Code", "input/60/parsed")?, // actually 60 and 61
-            self.diagnostic("warning_code", "Warning Code", "input/62/parsed")?, // actually 62 and 63
+            self.diagnostic("fault_code", "Fault Code", "input/fault_code/parsed")?,
+            self.diagnostic("warning_code", "Warning Code", "input/warning_code/parsed")?,
             self.apparent_power("s_eps", "Apparent EPS Power")?,
             self.battery("soc", "Battery Percentage")?,
             self.duration("runtime", "Total Runtime")?,

--- a/src/home_assistant.rs
+++ b/src/home_assistant.rs
@@ -215,6 +215,7 @@ impl Config {
             Entity {
                 key: "fault_code",
                 name: "Fault Code",
+                entity_category: Some("diagnostic"),
                 state_topic: &format!(
                     "{}/{}/input/fault_code/parsed",
                     self.mqtt_config.namespace(),
@@ -226,6 +227,7 @@ impl Config {
             Entity {
                 key: "warning_code",
                 name: "Warning Code",
+                entity_category: Some("diagnostic"),
                 state_topic: &format!(
                     "{}/{}/input/warning_code/parsed",
                     self.mqtt_config.namespace(),

--- a/src/home_assistant.rs
+++ b/src/home_assistant.rs
@@ -78,6 +78,8 @@ pub struct Entity<'a> {
     value_template: ValueTemplate,
     #[serde(skip_serializing_if = "Option::is_none")]
     unit_of_measurement: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    icon: Option<&'a str>,
 
     device: Device,
     availability: Availability,
@@ -142,6 +144,7 @@ impl Config {
             device_class: None,
             state_class: None,
             unit_of_measurement: None,
+            icon: None,
             value_template: ValueTemplate::Default, // "{{ value_json.$key }}"
             // TODO: might change this to an enum that defaults to InputsAll but can be replaced
             // with a string for a specific topic?
@@ -222,6 +225,7 @@ impl Config {
                     self.inverter.datalog()
                 ),
                 value_template: ValueTemplate::None,
+                icon: Some("mdi:alert"),
                 ..base.clone()
             },
             Entity {
@@ -234,6 +238,7 @@ impl Config {
                     self.inverter.datalog()
                 ),
                 value_template: ValueTemplate::None,
+                icon: Some("mdi:alert-outline"),
                 ..base.clone()
             },
             Entity {

--- a/src/home_assistant.rs
+++ b/src/home_assistant.rs
@@ -487,16 +487,13 @@ impl Config {
         sensors
             .map(|sensor| {
                 // fill in unique_id and value_template (if default) which are derived from key
-                let value_template = if sensor.value_template.is_default() {
-                    ValueTemplate::from_default(sensor.key)
-                } else {
-                    sensor.value_template
-                };
-                let sensor = Entity {
+                let mut sensor = Entity {
                     unique_id: &self.unique_id(sensor.key),
-                    value_template,
                     ..sensor
                 };
+                if sensor.value_template.is_default() {
+                    sensor.value_template = ValueTemplate::from_default(sensor.key);
+                }
 
                 mqtt::Message {
                     topic: self.ha_discovery_topic("sensor", sensor.key),

--- a/src/home_assistant.rs
+++ b/src/home_assistant.rs
@@ -30,9 +30,9 @@ pub struct Sensor {
     #[serde(skip_serializing_if = "Option::is_none")]
     entity_category: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    device_class: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     state_class: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    device_class: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     value_template: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/home_assistant.rs
+++ b/src/home_assistant.rs
@@ -94,7 +94,6 @@ impl Config {
     pub fn all(&self) -> Result<Vec<mqtt::Message>> {
         let r = vec![
             self.diagnostic("status", "Status", "input/0/parsed")?,
-            self.diagnostic("internal_fault", "Internal Fault", "input/6/parsed")?,
             self.diagnostic("fault_code", "Fault Code", "input/fault_code/parsed")?,
             self.diagnostic("warning_code", "Warning Code", "input/warning_code/parsed")?,
             self.apparent_power("s_eps", "Apparent EPS Power")?,

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -1257,11 +1257,15 @@ impl StatusString {
 pub struct WarningCodeString;
 impl WarningCodeString {
     pub fn from_value(value: u16) -> &'static str {
+        if value == 0 {
+            return "OK";
+        }
+
         let arr = [0; 31];
         arr.iter()
             .position(|i| value & (1 << i) > 0)
             .map(Self::from_bit)
-            .unwrap_or("OK")
+            .unwrap()
     }
 
     fn from_bit(bit: usize) -> &'static str {
@@ -1307,11 +1311,15 @@ impl WarningCodeString {
 pub struct FaultCodeString;
 impl FaultCodeString {
     pub fn from_value(value: u16) -> &'static str {
+        if value == 0 {
+            return "OK";
+        }
+
         let arr = [0; 31];
         arr.iter()
             .position(|i| value & (1 << i) > 0)
             .map(Self::from_bit)
-            .unwrap_or("OK")
+            .unwrap()
     }
 
     fn from_bit(bit: usize) -> &'static str {

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -1253,3 +1253,54 @@ impl StatusString {
         }
     }
 }
+
+pub struct WarningCodeString;
+impl WarningCodeString {
+    pub fn from_value(value: u16) -> &'static str {
+        let arr = [0; 31];
+        arr.iter()
+            .position(|i| value & (1 << i) > 0)
+            .and_then(|i| Some(Self::from_bit(i)))
+            .or(Some("OK"))
+            .unwrap()
+    }
+
+    fn from_bit(bit: usize) -> &'static str {
+        match bit {
+            0 => "W000: Battery communication failure",
+            1 => "W001: AFCI communication failure",
+            2 => "W002: AFCI high",
+            3 => "W003: Meter communication failure",
+            4 => "W004: Both charge and discharge forbidden by battery",
+            5 => "W005: Auto test failed",
+            6 => "W006: Reserved",
+            7 => "W007: LCD communication failure",
+            8 => "W008: FW version mismatch",
+            9 => "W009: Fan stuck",
+            10 => "W010: Reserved",
+            11 => "W011: Parallel number out of range",
+            12 => "W012: Bat On Mos",
+            13 => "W013: Overtemperature (NTC reading is too high)",
+            14 => "W014: Reserved",
+            15 => "W015: Battery reverse connection",
+            16 => "W016: Grid power outage",
+            17 => "W017: Grid voltage out of range",
+            18 => "W018: Grid frequency out of range",
+            19 => "W019: Reserved",
+            20 => "W020: PV insulation low",
+            21 => "W021: Leakage current high",
+            22 => "W022: DCI high",
+            23 => "W023: PV short",
+            24 => "W024: Reserved",
+            25 => "W025: Battery voltage high",
+            26 => "W026: Battery voltage low",
+            27 => "W027: Battery open circuit",
+            28 => "W028: EPS overload",
+            29 => "W029: EPS voltage high",
+            30 => "W030: Meter reverse connection",
+            31 => "W031: DCV high",
+
+            _ => todo!("Unknown Warning"),
+        }
+    }
+}

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -1260,9 +1260,8 @@ impl WarningCodeString {
         let arr = [0; 31];
         arr.iter()
             .position(|i| value & (1 << i) > 0)
-            .and_then(|i| Some(Self::from_bit(i)))
-            .or(Some("OK"))
-            .unwrap()
+            .map(Self::from_bit)
+            .unwrap_or("OK")
     }
 
     fn from_bit(bit: usize) -> &'static str {
@@ -1311,9 +1310,8 @@ impl FaultCodeString {
         let arr = [0; 31];
         arr.iter()
             .position(|i| value & (1 << i) > 0)
-            .and_then(|i| Some(Self::from_bit(i)))
-            .or(Some("OK"))
-            .unwrap()
+            .map(Self::from_bit)
+            .unwrap_or("OK")
     }
 
     fn from_bit(bit: usize) -> &'static str {

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -1304,3 +1304,53 @@ impl WarningCodeString {
         }
     }
 }
+
+pub struct FaultCodeString;
+impl FaultCodeString {
+    pub fn from_value(value: u16) -> &'static str {
+        let arr = [0; 31];
+        arr.iter()
+            .position(|i| value & (1 << i) > 0)
+            .and_then(|i| Some(Self::from_bit(i)))
+            .or(Some("OK"))
+            .unwrap()
+    }
+
+    fn from_bit(bit: usize) -> &'static str {
+        match bit {
+            0 => "E000: Internal communication fault 1",
+            1 => "E001: Model fault",
+            2 => "E002: BatOnMosFail",
+            3 => "E003: CT Fail",
+            4 => "E004: Reserved",
+            5 => "E005: Reserved",
+            6 => "E006: Reserved",
+            7 => "E007: Reserved",
+            8 => "E008: CAN communication error in parallel system",
+            9 => "E009: master lost in parallel system",
+            10 => "E010: multiple master units in parallel system",
+            11 => "E011: AC input inconsistent in parallel system",
+            12 => "E012: UPS short",
+            13 => "E013: Reverse current on UPS output",
+            14 => "E014: Bus short",
+            15 => "E015: Phase error in three phase system",
+            16 => "E016: Relay check fault",
+            17 => "E017: Internal communication fault 2",
+            18 => "E018: Internal communication fault 3",
+            19 => "E019: Bus voltage high",
+            20 => "E020: EPS connection fault",
+            21 => "E021: PV voltage high",
+            22 => "E022: Over current protection",
+            23 => "E023: Neutral fault",
+            24 => "E024: PV short",
+            25 => "E025: Radiator temperature over range",
+            26 => "E026: Internal fault",
+            27 => "E027: Sample inconsistent between Main CPU and redundant CPU",
+            28 => "E028: Reserved",
+            29 => "E029: Reserved",
+            30 => "E030: Reserved",
+            31 => "E031: Internal communication fault 4",
+            _ => todo!("Unknown Fault"),
+        }
+    }
+}

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -1256,14 +1256,13 @@ impl StatusString {
 
 pub struct WarningCodeString;
 impl WarningCodeString {
-    pub fn from_value(value: u16) -> &'static str {
+    pub fn from_value(value: u32) -> &'static str {
         if value == 0 {
             return "OK";
         }
 
-        let arr = [0; 31];
-        arr.iter()
-            .position(|i| value & (1 << i) > 0)
+        (0..=31)
+            .find(|i| value & (1 << i) > 0)
             .map(Self::from_bit)
             .unwrap()
     }
@@ -1310,14 +1309,13 @@ impl WarningCodeString {
 
 pub struct FaultCodeString;
 impl FaultCodeString {
-    pub fn from_value(value: u16) -> &'static str {
+    pub fn from_value(value: u32) -> &'static str {
         if value == 0 {
             return "OK";
         }
 
-        let arr = [0; 31];
-        arr.iter()
-            .position(|i| value & (1 << i) > 0)
+        (0..=31)
+            .find(|i| value & (1 << i) > 0)
             .map(Self::from_bit)
             .unwrap()
     }

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -1228,3 +1228,28 @@ impl Parser {
         Ok(r)
     }
 }
+
+pub struct StatusString;
+impl StatusString {
+    pub fn from_value(status: u16) -> &'static str {
+        match status {
+            0x00 => "Standby",
+            0x02 => "FW Updating",
+            0x04 => "PV On-grid",
+            0x08 => "PV Charge",
+            0x0C => "PV Charge On-grid",
+            0x10 => "Battery On-grid",
+            0x11 => "Bypass",
+            0x14 => "PV & Battery On-grid",
+            0x19 => "PV Charge + Bypass",
+            0x20 => "AC Charge",
+            0x28 => "PV & AC Charge",
+            0x40 => "Battery Off-grid",
+            0x80 => "PV Off-grid",
+            0xC0 => "PV & Battery Off-grid",
+            0x88 => "PV Charge Off-grid",
+
+            _ => "Unknown",
+        }
+    }
+}

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -103,20 +103,20 @@ impl Message {
                 }
 
                 if register == 60 {
-                    fault_code |= value;
+                    fault_code |= value as u32;
                     fault_code_registers_seen = true;
                 }
                 if register == 61 {
-                    fault_code |= value << 8;
+                    fault_code |= (value as u32) << 16;
                     fault_code_registers_seen = true;
                 }
 
                 if register == 62 {
-                    warning_code |= value;
+                    warning_code |= value as u32;
                     warning_code_registers_seen = true;
                 }
                 if register == 63 {
-                    warning_code |= value << 8;
+                    warning_code |= (value as u32) << 16;
                     warning_code_registers_seen = true;
                 }
             }

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -96,6 +96,17 @@ impl Message {
                         payload: lxp::packet::StatusString::from_value(value).to_owned(),
                     });
                 }
+
+                if register == 60 {
+                    // this should actually read 60 and 61, as they are L and H bytes of fault_code
+                    // respectively. But this mechanism doesn't support that as we only have access
+                    // to a single register here. Fortunately I think the H byte isn't used as they
+                    // only go up to 31.
+                }
+
+                if register == 62 {
+                    // this should actually read 62 and 63 - see above
+                }
             }
         }
 

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -129,8 +129,13 @@ impl Message {
                 });
             }
 
-            // TODO deal with fault_code
-            debug!("fault_code = {}", fault_code);
+            if fault_code_registers_seen {
+                r.push(mqtt::Message {
+                    topic: format!("{}/input/fault_code/parsed", td.datalog),
+                    retain: false,
+                    payload: lxp::packet::FaultCodeString::from_value(fault_code).to_owned(),
+                });
+            }
         }
 
         match td.read_input() {

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -115,9 +115,14 @@ impl Message {
                 }
             }
 
-            // TODO deal with fault_code and warning_code
+            r.push(mqtt::Message {
+                topic: format!("{}/input/warning_code/parsed", td.datalog),
+                retain: false,
+                payload: lxp::packet::WarningCodeString::from_value(warning_code).to_owned(),
+            });
+
+            // TODO deal with fault_code
             debug!("fault_code = {}", fault_code);
-            debug!("warning_code = {}", warning_code);
         }
 
         match td.read_input() {
@@ -227,7 +232,7 @@ impl Message {
     }
 
     // not entirely happy with this return type but it avoids needing to expose a struct for now
-    pub fn payload_start_end_time(&self) -> Result<[u8; 4]> {
+    fn payload_start_end_time(&self) -> Result<[u8; 4]> {
         use serde::Deserialize;
         #[derive(Deserialize)]
         struct StartEndTime {
@@ -251,17 +256,17 @@ impl Message {
         ])
     }
 
-    pub fn payload_int_or_1(&self) -> Result<u16> {
+    fn payload_int_or_1(&self) -> Result<u16> {
         self.payload_int().or(Ok(1))
     }
 
-    pub fn payload_int(&self) -> Result<u16> {
+    fn payload_int(&self) -> Result<u16> {
         self.payload
             .parse()
             .map_err(|err| anyhow!("payload_int: {}", err))
     }
 
-    pub fn payload_bool(&self) -> bool {
+    fn payload_bool(&self) -> bool {
         matches!(
             self.payload.to_ascii_lowercase().as_str(),
             "1" | "t" | "true" | "on" | "y" | "yes"

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -88,6 +88,14 @@ impl Message {
                     retain: false,
                     payload: serde_json::to_string(&value)?,
                 });
+
+                if register == 0 {
+                    r.push(mqtt::Message {
+                        topic: format!("{}/input/{}/parsed", td.datalog, register),
+                        retain: false,
+                        payload: lxp::packet::StatusString::from_value(value).to_owned(),
+                    });
+                }
             }
         }
 

--- a/tests/test_home_assistant.rs
+++ b/tests/test_home_assistant.rs
@@ -12,7 +12,7 @@ async fn all_has_soc() {
     assert!(r.unwrap().contains(&mqtt::Message {
         topic: "homeassistant/sensor/lxp_2222222222/soc/config".to_string(),
         retain: true,
-        payload: r#"{"name":"State of Charge","state_topic":"lxp/2222222222/inputs/all","unique_id":"lxp_2222222222_soc","state_class":"measurement","device_class":"battery","value_template":"{{ value_json.soc }}","unit_of_measurement":"%","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
+        payload: r#"{"unique_id":"lxp_2222222222_soc","name":"State of Charge","state_topic":"lxp/2222222222/inputs/all","state_class":"measurement","device_class":"battery","value_template":"{{ value_json.soc }}","unit_of_measurement":"%","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
     }));
 }
 

--- a/tests/test_home_assistant.rs
+++ b/tests/test_home_assistant.rs
@@ -12,7 +12,7 @@ async fn all_has_soc() {
     assert!(r.unwrap().contains(&mqtt::Message {
         topic: "homeassistant/sensor/lxp_2222222222/soc/config".to_string(),
         retain: true,
-        payload: "{\"device_class\":\"battery\",\"name\":\"Battery Percentage\",\"state_topic\":\"lxp/2222222222/inputs/all\",\"state_class\":\"measurement\",\"value_template\":\"{{ value_json.soc }}\",\"unit_of_measurement\":\"%\",\"unique_id\":\"lxp_2222222222_soc\",\"device\":{\"manufacturer\":\"LuxPower\",\"name\":\"lxp_2222222222\",\"identifiers\":[\"lxp_2222222222\"]},\"availability\":{\"topic\":\"lxp/LWT\"}}".to_string()
+        payload: r#"{"name":"Battery Percentage","state_topic":"lxp/2222222222/inputs/all","unique_id":"lxp_2222222222_soc","state_class":"measurement","device_class":"battery","value_template":"{{ value_json.soc }}","unit_of_measurement":"%","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
     }));
 }
 
@@ -27,7 +27,7 @@ async fn all_has_v_pv_1() {
     assert!(r.unwrap().contains(&mqtt::Message {
         topic: "homeassistant/sensor/lxp_2222222222/v_pv_1/config".to_string(),
         retain: true,
-        payload: "{\"device_class\":\"voltage\",\"name\":\"Voltage (PV String 1)\",\"state_topic\":\"lxp/2222222222/inputs/all\",\"state_class\":\"measurement\",\"value_template\":\"{{ value_json.v_pv_1 }}\",\"unit_of_measurement\":\"V\",\"unique_id\":\"lxp_2222222222_v_pv_1\",\"device\":{\"manufacturer\":\"LuxPower\",\"name\":\"lxp_2222222222\",\"identifiers\":[\"lxp_2222222222\"]},\"availability\":{\"topic\":\"lxp/LWT\"}}".to_string()
+        payload: r#"{"name":"Voltage (PV String 1)","state_topic":"lxp/2222222222/inputs/all","unique_id":"lxp_2222222222_v_pv_1","state_class":"measurement","device_class":"voltage","value_template":"{{ value_json.v_pv_1 }}","unit_of_measurement":"V","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
     }));
 }
 
@@ -42,7 +42,7 @@ async fn all_has_p_pv() {
     assert!(r.unwrap().contains(&mqtt::Message {
         topic: "homeassistant/sensor/lxp_2222222222/p_pv/config".to_string(),
         retain: true,
-        payload: "{\"device_class\":\"power\",\"name\":\"Power (PV Array)\",\"state_topic\":\"lxp/2222222222/inputs/all\",\"state_class\":\"measurement\",\"value_template\":\"{{ value_json.p_pv }}\",\"unit_of_measurement\":\"W\",\"unique_id\":\"lxp_2222222222_p_pv\",\"device\":{\"manufacturer\":\"LuxPower\",\"name\":\"lxp_2222222222\",\"identifiers\":[\"lxp_2222222222\"]},\"availability\":{\"topic\":\"lxp/LWT\"}}".to_string()
+        payload: r#"{"name":"Power (PV Array)","state_topic":"lxp/2222222222/inputs/all","unique_id":"lxp_2222222222_p_pv","state_class":"measurement","device_class":"power","value_template":"{{ value_json.p_pv }}","unit_of_measurement":"W","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
     }));
 }
 
@@ -57,7 +57,22 @@ async fn all_has_e_pv_all() {
     assert!(r.unwrap().contains(&mqtt::Message {
         topic: "homeassistant/sensor/lxp_2222222222/e_pv_all/config".to_string(),
         retain: true,
-        payload: "{\"device_class\":\"energy\",\"name\":\"PV Generation (All time)\",\"state_topic\":\"lxp/2222222222/inputs/all\",\"state_class\":\"total_increasing\",\"value_template\":\"{{ value_json.e_pv_all }}\",\"unit_of_measurement\":\"kWh\",\"unique_id\":\"lxp_2222222222_e_pv_all\",\"device\":{\"manufacturer\":\"LuxPower\",\"name\":\"lxp_2222222222\",\"identifiers\":[\"lxp_2222222222\"]},\"availability\":{\"topic\":\"lxp/LWT\"}}".to_string()
+        payload: r#"{"name":"PV Generation (All time)","state_topic":"lxp/2222222222/inputs/all","unique_id":"lxp_2222222222_e_pv_all","state_class":"total_increasing","device_class":"energy","value_template":"{{ value_json.e_pv_all }}","unit_of_measurement":"kWh","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
+    }));
+}
+
+#[tokio::test]
+async fn all_has_fault_code() {
+    common_setup();
+
+    let config = Factory::example_config();
+    let r = home_assistant::Config::new(&config.inverters[0], &config.mqtt).all();
+
+    assert!(r.is_ok());
+    assert!(r.unwrap().contains(&mqtt::Message {
+        topic: "homeassistant/sensor/lxp_2222222222/fault_code/config".to_string(),
+        retain: true,
+        payload: r#"{"name":"Fault Code","state_topic":"lxp/2222222222/input/fault_code/parsed","unique_id":"lxp_2222222222_fault_code","entity_category":"diagnostic","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
     }));
 }
 
@@ -72,7 +87,7 @@ async fn all_has_switch_ac_charge() {
     assert!(r.unwrap().contains(&mqtt::Message {
         topic: "homeassistant/switch/lxp_2222222222/ac_charge/config".to_string(),
         retain: true,
-        payload: "{\"name\":\"AC Charge\",\"state_topic\":\"lxp/2222222222/hold/21/bits\",\"command_topic\":\"lxp/cmd/2222222222/set/ac_charge\",\"value_template\":\"{{ value_json.ac_charge_en }}\",\"unique_id\":\"lxp_2222222222_ac_charge\",\"device\":{\"manufacturer\":\"LuxPower\",\"name\":\"lxp_2222222222\",\"identifiers\":[\"lxp_2222222222\"]},\"availability\":{\"topic\":\"lxp/LWT\"}}".to_string() 
+        payload: r#"{"name":"AC Charge","state_topic":"lxp/2222222222/hold/21/bits","command_topic":"lxp/cmd/2222222222/set/ac_charge","value_template":"{{ value_json.ac_charge_en }}","unique_id":"lxp_2222222222_ac_charge","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
     }));
 }
 
@@ -87,7 +102,7 @@ async fn all_has_number_ac_charge_soc_limit_pct() {
     assert!(r.unwrap().contains(&mqtt::Message {
         topic: "homeassistant/number/lxp_2222222222/AcChargeSocLimit/config".to_string(),
         retain: true,
-        payload: "{\"name\":\"AC Charge Limit %\",\"state_topic\":\"lxp/2222222222/hold/67\",\"command_topic\":\"lxp/cmd/2222222222/set/hold/67\",\"value_template\":\"{{ float(value) }}\",\"unique_id\":\"lxp_2222222222_number_AcChargeSocLimit\",\"device\":{\"manufacturer\":\"LuxPower\",\"name\":\"lxp_2222222222\",\"identifiers\":[\"lxp_2222222222\"]},\"availability\":{\"topic\":\"lxp/LWT\"},\"min\":0.0,\"max\":100.0,\"step\":1.0,\"unit_of_measurement\":\"%\"}".to_string()
+        payload: r#"{"name":"AC Charge Limit %","state_topic":"lxp/2222222222/hold/67","command_topic":"lxp/cmd/2222222222/set/hold/67","value_template":"{{ float(value) }}","unique_id":"lxp_2222222222_number_AcChargeSocLimit","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"},"min":0.0,"max":100.0,"step":1.0,"unit_of_measurement":"%"}"#.to_string()
     }));
 }
 

--- a/tests/test_home_assistant.rs
+++ b/tests/test_home_assistant.rs
@@ -72,7 +72,7 @@ async fn all_has_fault_code() {
     assert!(r.unwrap().contains(&mqtt::Message {
         topic: "homeassistant/sensor/lxp_2222222222/fault_code/config".to_string(),
         retain: true,
-        payload: r#"{"unique_id":"lxp_2222222222_fault_code","name":"Fault Code","state_topic":"lxp/2222222222/input/fault_code/parsed","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}ilability":{"topic":"lxp/LWT"}}"#.to_string()
+        payload: r#"{"unique_id":"lxp_2222222222_fault_code","name":"Fault Code","state_topic":"lxp/2222222222/input/fault_code/parsed","entity_category":"diagnostic","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
     }));
 }
 

--- a/tests/test_home_assistant.rs
+++ b/tests/test_home_assistant.rs
@@ -72,7 +72,7 @@ async fn all_has_fault_code() {
     assert!(r.unwrap().contains(&mqtt::Message {
         topic: "homeassistant/sensor/lxp_2222222222/fault_code/config".to_string(),
         retain: true,
-        payload: r#"{"unique_id":"lxp_BA19260024_fault_code","name":"Fault Code","state_topic":"lxp/BA19260024/input/fault_code/parsed","entity_category":"diagnostic","icon":"mdi:alert","device":{"manufacturer":"LuxPower","name":"lxp_BA19260024","identifiers":["lxp_BA19260024"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
+        payload: r#"{"unique_id":"lxp_2222222222_fault_code","name":"Fault Code","state_topic":"lxp/2222222222/input/fault_code/parsed","entity_category":"diagnostic","icon":"mdi:alert","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
     }));
 }
 

--- a/tests/test_home_assistant.rs
+++ b/tests/test_home_assistant.rs
@@ -27,7 +27,7 @@ async fn all_has_v_pv_1() {
     assert!(r.unwrap().contains(&mqtt::Message {
         topic: "homeassistant/sensor/lxp_2222222222/v_pv_1/config".to_string(),
         retain: true,
-        payload: r#"{"name":"Voltage (PV String 1)","state_topic":"lxp/2222222222/inputs/all","unique_id":"lxp_2222222222_v_pv_1","state_class":"measurement","device_class":"voltage","value_template":"{{ value_json.v_pv_1 }}","unit_of_measurement":"V","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
+        payload: r#"{"unique_id":"lxp_2222222222_v_pv_1","name":"PV Voltage (String 1)","state_topic":"lxp/2222222222/inputs/all","state_class":"measurement","device_class":"voltage","value_template":"{{ value_json.v_pv_1 }}","unit_of_measurement":"V","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
     }));
 }
 
@@ -42,7 +42,7 @@ async fn all_has_p_pv() {
     assert!(r.unwrap().contains(&mqtt::Message {
         topic: "homeassistant/sensor/lxp_2222222222/p_pv/config".to_string(),
         retain: true,
-        payload: r#"{"name":"Power (PV Array)","state_topic":"lxp/2222222222/inputs/all","unique_id":"lxp_2222222222_p_pv","state_class":"measurement","device_class":"power","value_template":"{{ value_json.p_pv }}","unit_of_measurement":"W","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
+        payload: r#"{"unique_id":"lxp_2222222222_p_pv","name":"PV Power (Array)","state_topic":"lxp/2222222222/inputs/all","state_class":"measurement","device_class":"power","value_template":"{{ value_json.p_pv }}","unit_of_measurement":"W","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
     }));
 }
 
@@ -57,7 +57,7 @@ async fn all_has_e_pv_all() {
     assert!(r.unwrap().contains(&mqtt::Message {
         topic: "homeassistant/sensor/lxp_2222222222/e_pv_all/config".to_string(),
         retain: true,
-        payload: r#"{"name":"PV Generation (All time)","state_topic":"lxp/2222222222/inputs/all","unique_id":"lxp_2222222222_e_pv_all","state_class":"total_increasing","device_class":"energy","value_template":"{{ value_json.e_pv_all }}","unit_of_measurement":"kWh","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
+        payload: r#"{"unique_id":"lxp_2222222222_e_pv_all","name":"PV Generation (All time)","state_topic":"lxp/2222222222/inputs/all","state_class":"total_increasing","device_class":"energy","value_template":"{{ value_json.e_pv_all }}","unit_of_measurement":"kWh","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
     }));
 }
 
@@ -72,7 +72,7 @@ async fn all_has_fault_code() {
     assert!(r.unwrap().contains(&mqtt::Message {
         topic: "homeassistant/sensor/lxp_2222222222/fault_code/config".to_string(),
         retain: true,
-        payload: r#"{"name":"Fault Code","state_topic":"lxp/2222222222/input/fault_code/parsed","unique_id":"lxp_2222222222_fault_code","entity_category":"diagnostic","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
+        payload: r#"{"unique_id":"lxp_2222222222_fault_code","name":"Fault Code","state_topic":"lxp/2222222222/input/fault_code/parsed","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}ilability":{"topic":"lxp/LWT"}}"#.to_string()
     }));
 }
 

--- a/tests/test_home_assistant.rs
+++ b/tests/test_home_assistant.rs
@@ -12,7 +12,7 @@ async fn all_has_soc() {
     assert!(r.unwrap().contains(&mqtt::Message {
         topic: "homeassistant/sensor/lxp_2222222222/soc/config".to_string(),
         retain: true,
-        payload: r#"{"name":"Battery Percentage","state_topic":"lxp/2222222222/inputs/all","unique_id":"lxp_2222222222_soc","state_class":"measurement","device_class":"battery","value_template":"{{ value_json.soc }}","unit_of_measurement":"%","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
+        payload: r#"{"name":"State of Charge","state_topic":"lxp/2222222222/inputs/all","unique_id":"lxp_2222222222_soc","state_class":"measurement","device_class":"battery","value_template":"{{ value_json.soc }}","unit_of_measurement":"%","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
     }));
 }
 

--- a/tests/test_home_assistant.rs
+++ b/tests/test_home_assistant.rs
@@ -72,7 +72,7 @@ async fn all_has_fault_code() {
     assert!(r.unwrap().contains(&mqtt::Message {
         topic: "homeassistant/sensor/lxp_2222222222/fault_code/config".to_string(),
         retain: true,
-        payload: r#"{"unique_id":"lxp_2222222222_fault_code","name":"Fault Code","state_topic":"lxp/2222222222/input/fault_code/parsed","entity_category":"diagnostic","device":{"manufacturer":"LuxPower","name":"lxp_2222222222","identifiers":["lxp_2222222222"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
+        payload: r#"{"unique_id":"lxp_BA19260024_fault_code","name":"Fault Code","state_topic":"lxp/BA19260024/input/fault_code/parsed","entity_category":"diagnostic","icon":"mdi:alert","device":{"manufacturer":"LuxPower","name":"lxp_BA19260024","identifiers":["lxp_BA19260024"]},"availability":{"topic":"lxp/LWT"}}"#.to_string()
     }));
 }
 

--- a/tests/test_mqtt_message.rs
+++ b/tests/test_mqtt_message.rs
@@ -168,6 +168,11 @@ async fn for_input() {
                 payload: "0".to_owned()
             },
             mqtt::Message {
+                topic: "2222222222/input/0/parsed".to_owned(),
+                retain: false,
+                payload: "Standby".to_owned()
+            },
+            mqtt::Message {
                 topic: "2222222222/input/1".to_owned(),
                 retain: false,
                 payload: "0".to_owned()

--- a/tests/test_mqtt_message.rs
+++ b/tests/test_mqtt_message.rs
@@ -222,7 +222,7 @@ async fn for_input_warning_codes() {
         device_function: lxp::packet::DeviceFunction::ReadInput,
         inverter: inverter.serial,
         register: 62,
-        values: [1, 0, 0, 0].to_vec(),
+        values: [0, 0, 0, 128].to_vec(),
     };
 
     assert_eq!(
@@ -231,17 +231,17 @@ async fn for_input_warning_codes() {
             mqtt::Message {
                 topic: "2222222222/input/62".to_owned(),
                 retain: false,
-                payload: "1".to_owned()
+                payload: "0".to_owned()
             },
             mqtt::Message {
                 topic: "2222222222/input/63".to_owned(),
                 retain: false,
-                payload: "0".to_owned()
+                payload: "32768".to_owned()
             },
             mqtt::Message {
                 topic: "2222222222/input/warning_code/parsed".to_owned(),
                 retain: false,
-                payload: "W000: Battery communication failure".to_owned()
+                payload: "W031: DCV high".to_owned()
             }
         ]
     );

--- a/tests/test_mqtt_message.rs
+++ b/tests/test_mqtt_message.rs
@@ -176,6 +176,35 @@ async fn for_input() {
                 topic: "2222222222/input/1".to_owned(),
                 retain: false,
                 payload: "0".to_owned()
+            },
+        ]
+    );
+
+    let packet = lxp::packet::TranslatedData {
+        datalog: inverter.datalog,
+        device_function: lxp::packet::DeviceFunction::ReadInput,
+        inverter: inverter.serial,
+        register: 62,
+        values: [1, 0, 0, 0].to_vec(),
+    };
+
+    assert_eq!(
+        mqtt::Message::for_input(packet, true).unwrap(),
+        vec![
+            mqtt::Message {
+                topic: "2222222222/input/62".to_owned(),
+                retain: false,
+                payload: "1".to_owned()
+            },
+            mqtt::Message {
+                topic: "2222222222/input/63".to_owned(),
+                retain: false,
+                payload: "0".to_owned()
+            },
+            mqtt::Message {
+                topic: "2222222222/input/warning_code/parsed".to_owned(),
+                retain: false,
+                payload: "W000: Battery communication failure".to_owned()
             }
         ]
     );

--- a/tests/test_mqtt_message.rs
+++ b/tests/test_mqtt_message.rs
@@ -179,6 +179,43 @@ async fn for_input() {
             },
         ]
     );
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "mocks"), ignore)]
+async fn for_input_warning_codes() {
+    common_setup();
+
+    let inverter = Factory::inverter();
+
+    let packet = lxp::packet::TranslatedData {
+        datalog: inverter.datalog,
+        device_function: lxp::packet::DeviceFunction::ReadInput,
+        inverter: inverter.serial,
+        register: 62,
+        values: [0, 0, 0, 0].to_vec(),
+    };
+
+    assert_eq!(
+        mqtt::Message::for_input(packet, true).unwrap(),
+        vec![
+            mqtt::Message {
+                topic: "2222222222/input/62".to_owned(),
+                retain: false,
+                payload: "0".to_owned()
+            },
+            mqtt::Message {
+                topic: "2222222222/input/63".to_owned(),
+                retain: false,
+                payload: "0".to_owned()
+            },
+            mqtt::Message {
+                topic: "2222222222/input/warning_code/parsed".to_owned(),
+                retain: false,
+                payload: "OK".to_owned()
+            }
+        ]
+    );
 
     let packet = lxp::packet::TranslatedData {
         datalog: inverter.datalog,


### PR DESCRIPTION
Build upon #189 and #190 and get this working properly.

This will add status/faults/warnings as diagnostic sensors in HA, complete with translated values, as a table of integers isn't very useful.

Note that this will require the config option `mqtt.publish_individual_input` setting to `true` to work.

Wasn't really happy with the state of `src/home_assistant.rs`, it has turned into a bit of a mess, so I redesigned it. It's ended up a bit longer with a little more repetition but I think it will scale more easily in future and lends itself to per-entity tweaks much better.