### PR TITLE
Fix charge_priority_en in hold/21/bits message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Avoid floating point maths oddities in e_pv_day and e_pv_all calculations (#185)
 * Add internal_fault/warning_code/fault_code keys (#189, #190, #191)
 * Revert to unsigned integers for inverter registers/values (#196)
+* Fix charge_priority_en value in hold/21/bits MQTT message (#201)
 
 
 # 0.11.0 - 16th July 2023

--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -611,7 +611,7 @@ impl Register21Bits {
             sw_seamless_en: Self::is_bit_set(data, 1 << 8),
             set_to_standby: Self::is_bit_set(data, 1 << 9),
             forced_discharge_en: Self::is_bit_set(data, 1 << 10),
-            charge_priority_en: Self::is_bit_set(data, 1 << 1),
+            charge_priority_en: Self::is_bit_set(data, 1 << 11),
             iso_en: Self::is_bit_set(data, 1 << 12),
             gfci_en: Self::is_bit_set(data, 1 << 13),
             dci_en: Self::is_bit_set(data, 1 << 14),

--- a/tests/test_mqtt_message.rs
+++ b/tests/test_mqtt_message.rs
@@ -67,6 +67,22 @@ async fn for_hold_21() {
              mqtt::Message { topic: "2222222222/hold/21/bits".to_owned(), retain: true, payload: "{\"eps_en\":\"OFF\",\"ovf_load_derate_en\":\"OFF\",\"drms_en\":\"ON\",\"lvrt_en\":\"ON\",\"anti_island_en\":\"OFF\",\"neutral_detect_en\":\"OFF\",\"grid_on_power_ss_en\":\"OFF\",\"ac_charge_en\":\"OFF\",\"sw_seamless_en\":\"OFF\",\"set_to_standby\":\"ON\",\"forced_discharge_en\":\"OFF\",\"charge_priority_en\":\"OFF\",\"iso_en\":\"OFF\",\"gfci_en\":\"ON\",\"dci_en\":\"OFF\",\"feed_in_grid_en\":\"OFF\"}".to_owned() }
         ]
     );
+
+    // really should do every bit but thats very tedious.. lets just do this one for now
+    let packet = lxp::packet::TranslatedData {
+        datalog: inverter.datalog(),
+        device_function: lxp::packet::DeviceFunction::ReadHold,
+        inverter: inverter.serial(),
+        register: 21,
+        values: vec![0, 8],
+    };
+
+    assert_eq!(
+        mqtt::Message::for_hold(packet).unwrap(),
+        vec![mqtt::Message { topic: "2222222222/hold/21".to_owned(), retain: true, payload: "2048".to_owned() },
+             mqtt::Message { topic: "2222222222/hold/21/bits".to_owned(), retain: true, payload: "{\"eps_en\":\"OFF\",\"ovf_load_derate_en\":\"OFF\",\"drms_en\":\"OFF\",\"lvrt_en\":\"OFF\",\"anti_island_en\":\"OFF\",\"neutral_detect_en\":\"OFF\",\"grid_on_power_ss_en\":\"OFF\",\"ac_charge_en\":\"OFF\",\"sw_seamless_en\":\"OFF\",\"set_to_standby\":\"OFF\",\"forced_discharge_en\":\"OFF\",\"charge_priority_en\":\"ON\",\"iso_en\":\"OFF\",\"gfci_en\":\"OFF\",\"dci_en\":\"OFF\",\"feed_in_grid_en\":\"OFF\"}".to_owned() }
+        ]
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
`charge_priority_en` in `hold/21/bits` was incorrectly using bit 1, not bit 11.

This meant HA didn't see the correct value for Charge Priority enabled/disabled.

Fixes #200 