### PR TITLE
add ReadInput4 for registers 120-159

### DIFF
--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -87,6 +87,7 @@ impl Coordinator {
             ReadInputs(inverter, 1) => self.read_inputs(inverter, 0_u16, 40).await,
             ReadInputs(inverter, 2) => self.read_inputs(inverter, 40_u16, 40).await,
             ReadInputs(inverter, 3) => self.read_inputs(inverter, 80_u16, 40).await,
+            ReadInputs(inverter, 4) => self.read_inputs(inverter, 120_u16, 40).await,
             ReadInputs(_, _) => unreachable!(),
             ReadInput(inverter, register, count) => {
                 self.read_inputs(inverter, register, count).await
@@ -377,10 +378,11 @@ impl Coordinator {
 
                     Ok(ReadInput::ReadInput1(r1)) => entry.set_read_input_1(r1),
                     Ok(ReadInput::ReadInput2(r2)) => entry.set_read_input_2(r2),
-                    Ok(ReadInput::ReadInput3(r3)) => {
-                        let datalog = r3.datalog;
+                    Ok(ReadInput::ReadInput3(r3)) => entry.set_read_input_3(r3),
+                    Ok(ReadInput::ReadInput4(r4)) => {
+                        let datalog = r4.datalog;
 
-                        entry.set_read_input_3(r3);
+                        entry.set_read_input_4(r4);
 
                         if let Some(input) = entry.to_input_all() {
                             if self.config.mqtt().enabled() {

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -159,6 +159,11 @@ impl Message {
                 retain: false,
                 payload: serde_json::to_string(&r3)?,
             }),
+            Ok(ReadInput::ReadInput4(r4)) => r.push(mqtt::Message {
+                topic: format!("{}/inputs/4", td.datalog),
+                retain: false,
+                payload: serde_json::to_string(&r4)?,
+            }),
             Err(x) => warn!("ignoring {:?}", x),
         }
 


### PR DESCRIPTION
Generator data is available for EG4 18K on registers 120+. This adds a 4th ReadInput since only 40 registers can be read at once. Not much of 120-159 is populated on my EG4 18K so I only added what was populated that I could verify.

I've been reading v_gen, p_gen, f_gen for the last week (with AC coupled solar on the GEN port) into prometheus and the data looks correct.

EPS is after generator data but mine are all 0 so can't verify what those do - so left them out