### PR TITLE
Fix max_chg_curr and max_dischr_curr

### DIFF
--- a/src/lxp/packet.rs
+++ b/src/lxp/packet.rs
@@ -137,9 +137,9 @@ pub struct ReadInputAll {
     // 18 bytes of auto_test stuff here I'm not doing yet
     #[nom(SkipBefore(18))] // auto_test stuff, TODO..
     #[nom(SkipBefore(2))] // bat_brand, bat_com_type
-    #[nom(Parse = "Utils::le_u16_div100")]
+    #[nom(Parse = "Utils::le_u16_div10")]
     pub max_chg_curr: f64,
-    #[nom(Parse = "Utils::le_u16_div100")]
+    #[nom(Parse = "Utils::le_u16_div10")]
     pub max_dischg_curr: f64,
     #[nom(Parse = "Utils::le_u16_div10")]
     pub charge_volt_ref: f64,


### PR DESCRIPTION
Values are divided by 10 and not 100.

Verified against web dashboard of EG4 6000XP inverter.