### PR TITLE
Remove (and enable unconditionally) publish_individual_input config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.99.0 (road-to-1-0 branch)
 
 * Cache Hold/Input registers internally as they're seen for later use (#248)
+* Remove publish_individual_input configuration option (now they always are) (#250)
 
 
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -109,8 +109,6 @@ pub struct Mqtt {
 
     #[serde(default = "Config::default_mqtt_homeassistant")]
     pub homeassistant: HomeAssistant,
-
-    pub publish_individual_input: Option<bool>,
 }
 impl Mqtt {
     pub fn enabled(&self) -> bool {
@@ -139,10 +137,6 @@ impl Mqtt {
 
     pub fn homeassistant(&self) -> &HomeAssistant {
         &self.homeassistant
-    }
-
-    pub fn publish_individual_input(&self) -> bool {
-        self.publish_individual_input == Some(true)
     }
 } // }}}
 

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -410,7 +410,7 @@ impl Coordinator {
             // returns a Vec of messages to send. could be none;
             // not every packet produces an MQ message (eg, heartbeats),
             // and some produce >1 (multi-register ReadHold)
-            match Self::packet_to_messages(packet, self.config.mqtt().publish_individual_input()) {
+            match Self::packet_to_messages(packet) {
                 Ok(messages) => {
                     for message in messages {
                         let message = mqtt::ChannelData::Message(message);
@@ -505,14 +505,13 @@ impl Coordinator {
     }
 
     fn packet_to_messages(
-        packet: Packet,
-        publish_individual_input: bool,
+        packet: Packet
     ) -> Result<Vec<mqtt::Message>> {
         match packet {
             Packet::Heartbeat(_) => Ok(Vec::new()), // always no message
             Packet::TranslatedData(td) => match td.device_function {
                 DeviceFunction::ReadHold => mqtt::Message::for_hold(td),
-                DeviceFunction::ReadInput => mqtt::Message::for_input(td, publish_individual_input),
+                DeviceFunction::ReadInput => mqtt::Message::for_input(td),
                 DeviceFunction::WriteSingle => mqtt::Message::for_hold(td),
                 DeviceFunction::WriteMulti => Ok(Vec::new()), // TODO, for_hold might just work
             },


### PR DESCRIPTION
Now individual input mqtt messages will always be published, which is going to become necessary for HA to see them.