### PR TITLE
Remove old inputs/1/2/3/all publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Cache Hold/Input registers internally as they're seen for later use (#248)
 * Remove publish_individual_input configuration option (now they always are) (#250)
-
+* BREAKING CHANGE (temporary, maybe): inputs/1 /2 /3 /all messages removed (#252)
 
 
 # Unreleased (rolled into 0.99.0)


### PR DESCRIPTION
This is removing use of the old ReadInputs1 parser. Adding it back in with the new parsed values later.

This also removes the `param` messages but I doubt anyone cares. We barely know what any of them are anyway.