### PR TITLE
Move time register parsing out of time_register_ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Remove publish_individual_input configuration option (now they always are) (#250)
 * Convert HA to use individual inputs messages (#253)
 * New configuration open publish_inputs_all_trigger (#256)
+* Move time register messages into new parser (start+end times for AC Charge etc) (#259)
 
 
 # 0.13.0 - 27th October 2023

--- a/src/lxp/register_parser.rs
+++ b/src/lxp/register_parser.rs
@@ -269,7 +269,6 @@ impl Parser {
             start: format!("{:02}:{:02}", start[0], start[1]),
             end: format!("{:02}:{:02}", end[0], end[1]),
         };
-        debug!("{:?}", payload);
 
         Ok(ParsedValue::StringOwned(serde_json::to_string(&payload)?))
     }


### PR DESCRIPTION
Move time register parsing into new parser and out of TimeRegisterOps

This should make it easier to generate start/end JSON payloads for registers that require it, on any relevant incoming packets.

Small improvement to how we generate and send the message after setting the registers (re-read it back from the inverter).

Also fix retain bit for hold publishes.
