### PR TITLE
feat: Allow configurable inverter polling interval

### DIFF
--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -18,6 +18,7 @@ options:
     port: 8000
     serial: ""
     datalog: ""
+    read_timeout: 10
     heartbeats: false
     publish_holdings_on_connect: false
   databases:
@@ -44,6 +45,7 @@ schema:
     port: port
     serial: str
     datalog: str
+    read_timeout: int?
     heartbeats: bool
     publish_holdings_on_connect: bool
   databases:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -6,6 +6,7 @@ inverters:
   port: 8000
   serial: 5555555555
   datalog: 2222222222
+  read_timeout: 10 # seconds to wait for data from inverter before timing out and reconnecting. Default is 10s.
   heartbeats: false
   publish_holdings_on_connect: false
 - enabled: false

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,7 +67,7 @@ impl Inverter {
     }
 
     pub fn read_timeout(&self) -> u64 {
-        self.read_timeout.unwrap_or(900) // 15 minutes
+        self.read_timeout.unwrap_or(10) // 10 seconds
     }
 } // }}}
 


### PR DESCRIPTION
This change modifies the `lxp-bridge` to support a configurable `read_timeout` for inverters. This allows you to fetch data from the inverter at more regular intervals, enabling more "live" information in Home Assistant or other connected systems.

Key changes:
- Modified `src/config.rs` to change the default `read_timeout` for inverters from 900 seconds (15 minutes) to 10 seconds.
- Updated `config.yaml.example` to include the `read_timeout` option with the new default and an explanatory comment.
- Updated `addon/config.yaml` to add `read_timeout` to both the schema and the default options for inverters. This makes the setting configurable for you if you are using the Home Assistant addon.